### PR TITLE
add servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 POC about a web sitac for Foothold missions
 
-# Work on this project
+## Work or install this project
+
+Define an environment var DCS_SAVED_GAMES_PATH (ex: C:\Users\veaf\Saved Games)
 
 ```shell
 git clone git@github.com:VEAF/foothold-sitac.git
 
 cd foothold-sitac
 poetry install
-poetry shell
-
-python -m app.main
+poetry run python -m app.main
 ```
 
 ## POC Notes

--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -1,25 +1,52 @@
-import os
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException, status
 from fastapi.responses import HTMLResponse
-from app.foothold import load_sitac
+from app.foothold import detect_foothold_mission_path, get_server_path_by_name, list_servers, load_sitac
 from jinja2 import Environment, FileSystemLoader
 
 env = Environment(loader=FileSystemLoader('templates'))
 
 router = APIRouter()
 
-FOOTHOLD_SITAC_PATH = os.getenv("FOOTHOLD_SITAC_PATH", "var/footholdSyria_Extended_0.1.lua")
-
 
 @router.get("", response_class=HTMLResponse)
-async def view_sitac(request: Request):
+async def foothold_servers(request: Request):
 
-    sitac = load_sitac(FOOTHOLD_SITAC_PATH)
+    servers = list_servers()
 
-    template = env.get_template("sitac.html")
+    template = env.get_template("foothold/servers.html")
+    return template.render(
+        {
+            "request": request,
+            "servers": servers,
+        }
+    )
+
+
+@router.get("/sitac/{server}", response_class=HTMLResponse)
+async def foothold_sitac(request: Request, server: str):
+
+    server_path = get_server_path_by_name(server)
+
+    if not server_path.is_dir():
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"server {server} not found")
+
+    mission_path = detect_foothold_mission_path(server_path)
+
+    if not mission_path:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"mission not found for server {server}")
+
+    sitac = load_sitac(mission_path)
+
+    template = env.get_template("foothold/sitac.html")
     return template.render(
         {
             "request": request,
             "sitac": sitac,
         }
     )
+
+
+@router.get("/ranking", response_class=HTMLResponse)
+async def view_ranking(request: Request):
+
+    raise Exception("TODO")

--- a/templates/foothold/servers.html
+++ b/templates/foothold/servers.html
@@ -6,6 +6,10 @@
     <title>DCS File Browser</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <link rel="stylesheet" ref="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
+        integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
+
     <style>
         body {
             font-family: "Segoe UI", Roboto, sans-serif;
@@ -62,8 +66,22 @@
         <h1>Welcome</h1>
         <p>Access to Foothold Sitac.</p>
 
-        <a class="cta-btn" href="{{ request.url_for('foothold_servers') }}">
-            Go to SITAC
+
+        <table>
+            {% for server in servers %}
+            <tr>
+                <td>
+                    <a href="{{ request.url_for('foothold_sitac', server=server) }}">{{ server }}</a>
+                </td>
+                <td>
+                    <a href="{{ request.url_for('foothold_sitac', server=server) }}"><i class="fa-solid fa-map-location-dot"></i> Map</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
+
+        <a class="cta-btn" href="{{ request.url_for('home') }}">
+            Back to home
         </a>
     </div>
 

--- a/templates/foothold/sitac.html
+++ b/templates/foothold/sitac.html
@@ -159,7 +159,7 @@
     </table>
 
     <div style="text-align:center;">
-        <a href="{{ request.url_for('home') }}" class="back-btn">Back to home</a>
+        <a href="{{ request.url_for('foothold_servers') }}" class="back-btn">Back to servers list</a>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary by Sourcery

Enable discovery of Foothold servers and missions from a configurable saved games directory, add corresponding API endpoints and HTML views for server listing and SITAC display, and revise documentation accordingly.

New Features:
- Add utility functions to detect missions, validate Foothold server paths, list servers, and resolve server directory paths
- Implement API endpoints to list available Foothold servers and retrieve SITAC data for a specified server with proper error handling
- Introduce a new servers list HTML template with links to individual server SITAC views
- Allow configuration of the DCS saved games directory via the DCS_SAVED_GAMES_PATH environment variable

Enhancements:
- Refactor load_sitac to accept Path objects and use absolute file paths
- Update existing templates to integrate server listing navigation and adjust styling and links

Documentation:
- Document DCS_SAVED_GAMES_PATH and update run instructions in the README