### PR TITLE
Feature/3 add map display

### DIFF
--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -1,11 +1,28 @@
-from fastapi import APIRouter, Request, HTTPException, status
+from typing import Annotated
+from fastapi import APIRouter, Depends, Request, HTTPException, status
 from fastapi.responses import HTMLResponse
-from app.foothold import detect_foothold_mission_path, get_server_path_by_name, list_servers, load_sitac
+from app.foothold import ZonePersistance, detect_foothold_mission_path, get_server_path_by_name, get_sitac_center, list_servers, load_sitac
 from jinja2 import Environment, FileSystemLoader
 
 env = Environment(loader=FileSystemLoader('templates'))
 
 router = APIRouter()
+
+
+def get_active_sitac(server: str) -> ZonePersistance:
+    """Dependency injection of sitac by server name"""
+
+    server_path = get_server_path_by_name(server)
+
+    if not server_path.is_dir():
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"server {server} not found")
+
+    mission_path = detect_foothold_mission_path(server_path)
+
+    if not mission_path:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"mission not found for server {server}")
+
+    return load_sitac(mission_path)
 
 
 @router.get("", response_class=HTMLResponse)
@@ -23,19 +40,7 @@ async def foothold_servers(request: Request):
 
 
 @router.get("/sitac/{server}", response_class=HTMLResponse)
-async def foothold_sitac(request: Request, server: str):
-
-    server_path = get_server_path_by_name(server)
-
-    if not server_path.is_dir():
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"server {server} not found")
-
-    mission_path = detect_foothold_mission_path(server_path)
-
-    if not mission_path:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"mission not found for server {server}")
-
-    sitac = load_sitac(mission_path)
+async def foothold_sitac(request: Request, sitac: Annotated[ZonePersistance, Depends(get_active_sitac)]):
 
     template = env.get_template("foothold/sitac.html")
     return template.render(
@@ -46,7 +51,35 @@ async def foothold_sitac(request: Request, server: str):
     )
 
 
-@router.get("/ranking", response_class=HTMLResponse)
-async def view_ranking(request: Request):
+@router.get("/map/{server}", response_class=HTMLResponse)
+async def foothold_map(request: Request, server: str, sitac: Annotated[ZonePersistance, Depends(get_active_sitac)]):
 
-    raise Exception("TODO")
+    template = env.get_template("foothold/map.html")
+    map_center = get_sitac_center(sitac)
+
+    return template.render(
+        {
+            "request": request,
+            "sitac": sitac,
+            "server": server,
+            "center": [map_center.latitude, map_center.longitude],
+        }
+    )
+
+
+@router.get("/map/{server}/data.json")
+async def foothold_map_data(request: Request, sitac: Annotated[ZonePersistance, Depends(get_active_sitac)]):
+
+    # sitac = load_sitac(FOOTHOLD_SITAC_PATH)  # todo use real data
+    zones: list[dict[str, str | float]] = [
+        {
+            "name": zone_name,
+            "lat": zone.position.latitude,
+            "lon": zone.position.longitude,
+            "side": zone.side_str,
+            "color": zone.side_color
+        }
+        for zone_name, zone in sitac.zones.items() if zone.position
+    ]
+
+    return zones

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -20,36 +20,37 @@
         map_center = JSON.parse('{{ center }}')
         const map = L.map('map').setView(map_center, 7);
 
-        // Fond OpenStreetMap
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19,
             attribution: '&copy; OpenStreetMap'
         }).addTo(map);
 
-        // load data (todo: how to refresh ?)
-        fetch('{{ request.url_for("foothold_map_data", server=server) }}')
-            .then(r => r.json())
-            .then(data => {
-                data.forEach(p => {
+        const zonesLayer = L.layerGroup().addTo(map);
+
+        function loadData() {
+            fetch('{{ request.url_for("foothold_map_data", server=server) }}')
+                .then(r => r.json())
+                .then(data => {
+                    zonesLayer.clearLayers()
+                    data.forEach(p => {
 
 
-                    var circle = L.circle([p.lat, p.lon], {
-                        color: p.color,
-                        fillColor: p.color,
-                        fillOpacity: 0.3,
-                        radius: 10000
-                    }).addTo(map)
-                        .bindPopup(p.name || `${p.lat}, ${p.lon}`);
-                    ;
+                        var circle = L.circle([p.lat, p.lon], {
+                            color: p.color,
+                            fillColor: p.color,
+                            fillOpacity: 0.3,
+                            radius: 10000
+                        }).addTo(zonesLayer)
+                            .bindPopup(p.name || `${p.lat}, ${p.lon}`);
+                        ;
 
-                    /*
-                    L.marker([p.lat, p.lon])
-                        .addTo(map)
-                        .bindPopup(p.name || `${p.lat}, ${p.lon}`); 
-                    */
-                });
-            })
-            .catch(console.error);
+                    });
+                })
+                .catch(console.error);
+        }
+
+        loadData(); // initial load
+        setInterval(loadData, 30000); // refresh every x ms
     </script>
 </body>
 

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Foothold SITAC - map</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <style>
+        #map {
+            height: 100vh;
+            width: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script>
+        map_center = JSON.parse('{{ center }}')
+        const map = L.map('map').setView(map_center, 7);
+
+        // Fond OpenStreetMap
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; OpenStreetMap'
+        }).addTo(map);
+
+        // load data (todo: how to refresh ?)
+        fetch('{{ request.url_for("foothold_map_data", server=server) }}')
+            .then(r => r.json())
+            .then(data => {
+                data.forEach(p => {
+
+
+                    var circle = L.circle([p.lat, p.lon], {
+                        color: p.color,
+                        fillColor: p.color,
+                        fillOpacity: 0.3,
+                        radius: 10000
+                    }).addTo(map)
+                        .bindPopup(p.name || `${p.lat}, ${p.lon}`);
+                    ;
+
+                    /*
+                    L.marker([p.lat, p.lon])
+                        .addTo(map)
+                        .bindPopup(p.name || `${p.lat}, ${p.lon}`); 
+                    */
+                });
+            })
+            .catch(console.error);
+    </script>
+</body>
+
+</html>

--- a/templates/foothold/servers.html
+++ b/templates/foothold/servers.html
@@ -3,10 +3,10 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>DCS File Browser</title>
+    <title>Foothold SITAC - map</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link rel="stylesheet" ref="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
         integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
 
@@ -39,6 +39,31 @@
 
         p {
             color: #555;
+        }
+
+        td {
+            padding: 10px 0;
+        }
+
+        a {
+            text-decoration: none;
+            color: #4263eb;
+            transition: color 0.2s ease, transform 0.15s ease;
+            font-weight: 500;
+        }
+
+        a:hover {
+            color: #274bde;
+            transform: translateY(-1px);
+        }
+
+        i {
+            margin-right: 6px;
+            color: #4263eb;
+        }
+
+        a:hover i {
+            color: #274bde;
         }
 
         .cta-btn {
@@ -74,7 +99,8 @@
                     <a href="{{ request.url_for('foothold_sitac', server=server) }}">{{ server }}</a>
                 </td>
                 <td>
-                    <a href="{{ request.url_for('foothold_sitac', server=server) }}"><i class="fa-solid fa-map-location-dot"></i> Map</a>
+                    <a href="{{ request.url_for('foothold_map', server=server) }}"><i
+                            class="fa-solid fa-map-location-dot"></i> Map</a>
                 </td>
             </tr>
             {% endfor %}

--- a/templates/foothold/sitac.html
+++ b/templates/foothold/sitac.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="fr">
+
 <head>
     <meta charset="UTF-8">
     <title>SITAC - Foothold</title>
@@ -19,7 +20,7 @@
             background: white;
             border-radius: 12px;
             padding: 40px 50px;
-            box-shadow: 0 8px 20px rgba(0,0,0,0.08);
+            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
         }
 
         h1 {
@@ -42,7 +43,8 @@
             margin-top: 15px;
         }
 
-        th, td {
+        th,
+        td {
             padding: 10px 12px;
             text-align: left;
         }
@@ -84,84 +86,94 @@
             color: white;
         }
 
-        .badge.blue { background: #4263eb; }
-        .badge.red { background: #e03131; }
-        .badge.grey { background: #868e96; }
+        .badge.blue {
+            background: #4263eb;
+        }
+
+        .badge.red {
+            background: #e03131;
+        }
+
+        .badge.grey {
+            background: #868e96;
+        }
     </style>
 </head>
+
 <body>
 
-<div class="container">
-    <h1>SITAC - Foothold</h1>
+    <div class="container">
+        <h1>SITAC - Foothold</h1>
 
-    <!-- Section ZONES -->
-    <h2>Zones</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Nom</th>
-                <th>Side</th>
-                <th>Level</th>
-                <th>Upgrades Used</th>
-                <th>Active</th>
-                <th>First Capture by Red</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for name, zone in sitac.zones.items()  | sort %}
-            <tr>
-                <td>{{ name }}</td>
-                <td>
-                    {% if zone.side == 1 %}
+        <!-- Section ZONES -->
+        <h2>Zones</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Side</th>
+                    <th>Level</th>
+                    <th>Upgrades Used</th>
+                    <th>Active</th>
+                    <th>First Capture by Red</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, zone in sitac.zones.items() | sort %}
+                <tr>
+                    <td>{{ name }}</td>
+                    <td>
+                        {% if zone.side == 1 %}
                         <span class="badge red">Red</span>
-                    {% elif zone.side == 2 %}
+                        {% elif zone.side == 2 %}
                         <span class="badge blue">Blue</span>
-                    {% else %}
+                        {% else %}
                         <span class="badge grey">Neutral</span>
-                    {% endif %}
-                </td>
-                <td class="n">{{ zone.level }}</td>
-                <td class="n">{{ zone.upgradesUsed }}</td>
-                <td>{{ 'Yes' if zone.active else 'No' }}</td>
-                <td>{{ 'Yes' if zone.firstCaptureByRed else 'No' }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+                        {% endif %}
+                    </td>
+                    <td class="n">{{ zone.level }}</td>
+                    <td class="n">{{ zone.upgradesUsed }}</td>
+                    <td>{{ 'Yes' if zone.active else 'No' }}</td>
+                    <td>{{ 'Yes' if zone.firstCaptureByRed else 'No' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
 
-    <!-- Section PLAYER STATS -->
-    <h2>Player Stats</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Player</th>
-                <th>Points</th>
-                <th>Deaths</th>
-                <th>Zone Captures</th>
-                <th>Zone Upgrades</th>
-                <th>Air</th>
-                <th>Ground Units</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for player, stats in sitac.playerStats.items() | sort(attribute='1.points', reverse=True) %}
-            <tr>
-                <td>{{ player }}</td>
-                <td class="n">{{ stats.points | int }}</td>
-                <td class="n">{{ stats.deaths }}</td>
-                <td class="n">{{ stats.zone_capture }}</td>
-                <td class="n">{{ stats.zone_upgrade }}</td>
-                <td class="n">{{ stats.air }}</td>
-                <td class="n">{{ stats.ground_units }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+        <!-- Section PLAYER STATS -->
+        <h2>Player Stats</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Player</th>
+                    <th>Points</th>
+                    <th>Deaths</th>
+                    <th>Zone Captures</th>
+                    <th>Zone Upgrades</th>
+                    <th>Air</th>
+                    <th>Ground Units</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for player, stats in sitac.playerStats.items() | sort(attribute='1.points', reverse=True) %}
+                <tr>
+                    <td>{{ player }}</td>
+                    <td class="n">{{ stats.points | int }}</td>
+                    <td class="n">{{ stats.deaths }}</td>
+                    <td class="n">{{ stats.zone_capture }}</td>
+                    <td class="n">{{ stats.zone_upgrade }}</td>
+                    <td class="n">{{ stats.air }}</td>
+                    <td class="n">{{ stats.ground_units }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
 
-    <div style="text-align:center;">
-        <a href="{{ request.url_for('foothold_servers') }}" class="back-btn">Back to servers list</a>
+        <div style="text-align:center;">
+            <a href="{{ request.url_for('foothold_servers') }}" class="back-btn">Back to servers list</a>
+        </div>
     </div>
-</div>
 
 </body>
+
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>DCS File Browser</title>
+    <title>Foothold SITAC</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <style>
@@ -62,10 +62,10 @@
         <h1>Welcome</h1>
         <p>Access to Foothold Sitac.</p>
 
-        <a class="cta-btn" href="{{ request.url_for('foothold_servers') }}">
-            Go to SITAC
-        </a>
-    </div>
+    <a class="cta-btn" href="{{ request.url_for('foothold_servers') }}">
+        Go to Foothold
+    </a>
+</div>
 
 </body>
 


### PR DESCRIPTION
## Summary by Sourcery

Add interactive map display for Foothold SITAC zones with new API endpoints and frontend integration using Leaflet.

New Features:
- Introduce Position model and extend Zone with side_color and side_str properties to support mapping.
- Add API endpoints '/map/{server}' and '/map/{server}/data.json' to serve map view and zone data respectively.
- Create map.html template with Leaflet to render zones on a map and auto-refresh data.
- Compute SITAC center coordinates with get_sitac_range and get_sitac_center for map centering.

Enhancements:
- Refactor foothold_router to use dependency injection for loading active SITAC.
- Update sitac, servers, and home templates for consistent styling and correct map links.