### PR TITLE
add configuration load from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,28 @@ POC about a web sitac for Foothold missions
 
 ## Work or install this project
 
-Define an environment var DCS_SAVED_GAMES_PATH (ex: C:\Users\veaf\Saved Games)
-
 ```shell
 git clone git@github.com:VEAF/foothold-sitac.git
-
 cd foothold-sitac
-poetry install
+```
+
+- Copy app/config.yml.dist to app/config.yml
+- Update app/config.yml values 
+- install dependencies:
+```shell
+poetry install --only main
+```
+- start web service
+```shell
 poetry run python -m app.main
 ```
 
-## POC Notes
+## Run tests
 
-- need a file var/footholdSyria_Extended_0.1.lua to work
-- service is exposed to http 8081 port
+```shell
+poetry run pytest
+```
+
+## Access to web service
+
+Default configuration: [localhost](http://localhost:8080)

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,51 @@
+import os
+from typing import Annotated, Any
+from functools import cache
+import yaml
+from pydantic import BaseModel, Field
+
+
+class WebConfig(BaseModel):
+
+    host: str = "0.0.0.0"
+    port: int = 8080
+    title: str = "Foothold Sitac Server"
+
+
+class DcsConfig(BaseModel):
+
+    saved_games: str = "var"  # "DCS Saved Games Path"
+
+
+class AppConfig(BaseModel):
+
+    web: Annotated[WebConfig, Field(default_factory=WebConfig)]
+    dcs: Annotated[DcsConfig, Field(default_factory=DcsConfig)]
+
+
+def load_config_str(raw_config: dict[Any, Any]) -> AppConfig:
+
+    # Recursively expand environment vars like "${VAR}" or "$VAR"
+    def expand(value):
+        if isinstance(value, str):
+            return os.path.expandvars(value)
+        if isinstance(value, dict):
+            return {k: expand(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [expand(v) for v in value]
+        return value
+
+    expanded = expand(raw_config)
+    return AppConfig.model_validate(expanded)
+
+
+def load_config(path: str) -> AppConfig:
+    with open(path, "r") as f:
+        raw_config = yaml.safe_load(f)
+
+    return load_config_str(raw_config)
+
+
+@cache
+def get_config() -> AppConfig:
+    return load_config("config/config.yml")

--- a/app/foothold.py
+++ b/app/foothold.py
@@ -1,10 +1,7 @@
-import os
 from pathlib import Path
 from lupa import LuaRuntime
 from pydantic import BaseModel, Field
-
-DCS_SAVED_GAMES_PATH = os.getenv("DCS_SAVED_GAMES_PATH", "var")
-
+from app.config import get_config
 
 class ConfigError(Exception):
     ...
@@ -125,10 +122,10 @@ def is_foothold_path(server_path: Path) -> bool:
 
 def list_servers() -> list[str]:
 
-    base_path = Path(DCS_SAVED_GAMES_PATH)
+    base_path = Path(get_config().dcs.saved_games)
 
     if not base_path.is_dir():
-        raise ConfigError(f"DCS_SAVED_GAMES_PATH '{DCS_SAVED_GAMES_PATH}' is not a valid dir")
+        raise ConfigError(f"config:dcs.saved_games '{get_config().dcs.saved_games}' is not a valid dir")
 
     return sorted([
         file.name for file in base_path.iterdir()
@@ -138,7 +135,7 @@ def list_servers() -> list[str]:
 
 def get_server_path_by_name(server: str) -> Path:
 
-    return Path(DCS_SAVED_GAMES_PATH) / server
+    return Path(get_config().dcs.saved_games) / server
 
 
 def get_sitac_range(sitac: ZonePersistance) -> tuple[Position, Position]:

--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -2,9 +2,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Request, HTTPException, status
 from fastapi.responses import HTMLResponse
 from app.foothold import ZonePersistance, detect_foothold_mission_path, get_server_path_by_name, get_sitac_center, list_servers, load_sitac
-from jinja2 import Environment, FileSystemLoader
-
-env = Environment(loader=FileSystemLoader('templates'))
+from app.templater import env
 
 router = APIRouter()
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,10 @@
 import uvicorn
 from fastapi.responses import HTMLResponse
 from fastapi import FastAPI, Request
-from jinja2 import Environment, FileSystemLoader
 from app.foothold_router import router as foothold_router
+from app.templater import env
 
 app = FastAPI()
-
-env = Environment(loader=FileSystemLoader('templates'))
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/app/templater.py
+++ b/app/templater.py
@@ -1,0 +1,5 @@
+from jinja2 import Environment, FileSystemLoader
+from app.config import get_config
+
+env = Environment(loader=FileSystemLoader('templates'))
+env.globals["config"] = get_config()  # add all variables accessibles in templates

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+config.yml

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -1,0 +1,12 @@
+# configuration of listening web server
+# copy this file to config.yml
+# uncomment and update customized values (commented are default values)
+web:
+  # ip address
+  # ip: 0.0.0.0
+
+  # port number
+  # port: 8080
+
+dcs:
+    saved_games: "C:\Users\veaf\Saved Games" # !! update your setup

--- a/poetry.lock
+++ b/poetry.lock
@@ -114,6 +114,17 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -326,6 +337,32 @@ files = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pydantic"
 version = "2.12.4"
 description = "Data validation using Python type hints"
@@ -480,6 +517,123 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
+    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pytest"
+version = "9.0.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad"},
+    {file = "pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198"},
+    {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0"},
+    {file = "pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e"},
+    {file = "pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e"},
+    {file = "pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00"},
+    {file = "pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a"},
+    {file = "pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b"},
+    {file = "pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196"},
+    {file = "pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c"},
+    {file = "pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e"},
+    {file = "pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b"},
+    {file = "pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8"},
+    {file = "pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5"},
+    {file = "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6"},
+    {file = "pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c"},
+    {file = "pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788"},
+    {file = "pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764"},
+    {file = "pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac"},
+    {file = "pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9"},
+    {file = "pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da"},
+    {file = "pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5"},
+    {file = "pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926"},
+    {file = "pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0"},
+    {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
+    {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -554,4 +708,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "f741c6c8cd6c8f1ac71174a590170f9ed37915a1b1e0a2c96b496dde6d4ed254"
+content-hash = "e0f46a97c77f9fe675fb0080fcee0a9241e3f3ad210c8ac3f587d88e91a2651f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Michel NAUD <michel.naud26400@gmail.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
@@ -12,8 +13,15 @@ uvicorn = "^0.38.0"
 jinja2 = "^3.1.6"
 pydantic = "^2.12.4"
 lupa = "^2.6"
+pyyaml = "^6.0.3"
 
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.0.1"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Foothold SITAC - map</title>
+    <title>{{ config.web.title }} - Map</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <style>
         #map {

--- a/templates/foothold/servers.html
+++ b/templates/foothold/servers.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Foothold SITAC - map</title>
+    <title>{{ config.web.title }} - Servers</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"

--- a/templates/foothold/sitac.html
+++ b/templates/foothold/sitac.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>SITAC - Foothold</title>
+    <title>{{ config.web.title }} - SITAC</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <style>

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Foothold SITAC</title>
+    <title>{{ config.web.title }} - Home</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <style>
@@ -62,10 +62,10 @@
         <h1>Welcome</h1>
         <p>Access to Foothold Sitac.</p>
 
-    <a class="cta-btn" href="{{ request.url_for('foothold_servers') }}">
-        Go to Foothold
-    </a>
-</div>
+        <a class="cta-btn" href="{{ request.url_for('foothold_servers') }}">
+            Go to Foothold
+        </a>
+    </div>
 
 </body>
 

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -1,0 +1,117 @@
+# test app/config.py
+
+import tempfile
+import yaml
+import pytest
+
+from app.config import (
+    load_config,
+    load_config_str,
+    AppConfig,
+)
+
+
+def write_tmp_yaml(content: dict) -> str:
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".yaml")
+    with open(tmp.name, "w") as f:
+        yaml.safe_dump(content, f)
+    return tmp.name
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1"])
+@pytest.mark.parametrize("port", [80, 8080, 8081])
+@pytest.mark.parametrize("title", ["Test Server", "VEAF SITAC"])
+def test_load_config_str_basic(host: str, port: int, title: str):
+
+    # GIVEN
+    raw = {
+        "web": {
+            "host": host,
+            "port": port,
+            "title": title,
+        }
+    }
+
+    # WHEN
+    cfg = load_config_str(raw)
+
+    # THEN
+    assert isinstance(cfg, AppConfig)
+    assert cfg.web.host == host
+    assert cfg.web.port == port
+    assert cfg.web.title == title
+
+
+def test_load_config_str_defaults():
+
+    # WHEN
+    cfg = load_config_str({})
+
+    # THEN
+    assert cfg.web.host == "0.0.0.0"
+    assert cfg.web.port == 8080
+    assert cfg.web.title == "Foothold Sitac Server"
+
+
+def test_load_config_str_env_expansion(monkeypatch):
+
+    # GIVEN
+    monkeypatch.setenv("WEB_HOST", "10.0.0.5")
+    monkeypatch.setenv("WEB_PORT", "7777")
+    monkeypatch.setenv("WEB_TITLE", "My Sitac")
+
+    raw = {
+        "web": {
+            "host": "${WEB_HOST}",
+            "port": "$WEB_PORT",
+            "title": "$WEB_TITLE",
+        }
+    }
+
+    # WHEN
+    cfg = load_config_str(raw)
+
+    # THEN
+    assert cfg.web.host == "10.0.0.5"
+    assert cfg.web.port == 7777
+    assert cfg.web.title == "My Sitac"
+
+
+def test_load_config_str_list_env_expansion(monkeypatch):
+
+    # GIVEN
+    monkeypatch.setenv("A", "abc")
+    monkeypatch.setenv("B", "def")
+
+    raw = {
+        "web": {"title": "$A - ${B}"},
+    }
+
+    # WHEN
+    cfg = load_config_str(raw)
+
+    # THEN
+    assert cfg.web.title == "abc - def"
+
+
+def test_load_config_from_file():
+
+    # GIVEN
+    path = write_tmp_yaml(
+        {
+            "web": {
+                "host": "1.2.3.4",
+                "port": 8888,
+                "title": "File Test",
+            }
+        }
+    )
+
+    # WHEN
+    cfg = load_config(path)
+
+    # THEN
+    assert isinstance(cfg, AppConfig)
+    assert cfg.web.host == "1.2.3.4"
+    assert cfg.web.port == 8888
+    assert cfg.web.title == "File Test"


### PR DESCRIPTION
## Summary by Sourcery

Introduce YAML-based configuration for web and DCS settings and refactor code and templates to consume these values, replacing hard-coded environment variables.

New Features:
- Add file-based configuration support with AppConfig, WebConfig, and DcsConfig loaded from YAML and environment variables
- Implement get_config() cache to globally access configuration values

Enhancements:
- Refactor application to use loaded config for DCS saved games path and web settings
- Centralize Jinja2 environment in app/templater and inject config globals, updating templates to use dynamic titles

Build:
- Add pyyaml dependency and configure pytest as a dev group dependency with pythonpath settings in pyproject.toml

Documentation:
- Update README to include setup steps for copying and editing config/config.yml, installing dependencies, running the service and tests

Tests:
- Add unit tests for configuration loading, defaults, and environment variable expansion