### PR TITLE
customize host, port, title

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,7 @@ class WebConfig(BaseModel):
     host: str = "0.0.0.0"
     port: int = 8080
     title: str = "Foothold Sitac Server"
+    reload: bool = False
 
 
 class DcsConfig(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,17 @@
 import uvicorn
 from fastapi.responses import HTMLResponse
 from fastapi import FastAPI, Request
+from app.config import get_config
 from app.foothold_router import router as foothold_router
 from app.templater import env
 
-app = FastAPI()
+config = get_config()
+
+app = FastAPI(
+    title=config.web.title,
+    version="0.1.0",
+    description="Foothold Web Sitac"
+)
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -12,13 +19,13 @@ async def home(request: Request):
     template = env.get_template("home.html")
     return template.render(request=request)
 
-app.include_router(foothold_router, prefix="/foothold")
+app.include_router(foothold_router, prefix="/foothold", tags=["foothold"])
 
 if __name__ == "__main__":
 
     uvicorn.run(
         "app.main:app",
-        host="0.0.0.0",
-        port=8081,
-        reload=True
+        host=config.web.host,
+        port=config.web.port,
+        reload=config.web.reload,
     )

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -8,5 +8,8 @@ web:
   # port number
   # port: 8080
 
+  # automatic python service reload when scripts are updated (dev environment only)
+  # reload: false
+
 dcs:
     saved_games: "C:\Users\veaf\Saved Games" # !! update your setup


### PR DESCRIPTION
## Summary by Sourcery

Customize FastAPI application metadata and server startup parameters through configuration and tag the foothold router for better API grouping.

New Features:
- Allow configuring FastAPI app title, description, and version via configuration
- Enable loading host, port, and reload settings from WebConfig for the server

Enhancements:
- Tag the foothold router endpoints with "foothold"