### PR TITLE
add sitac export

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,18 @@
+from fastapi import HTTPException, status
+from app.foothold import Sitac, detect_foothold_mission_path, get_server_path_by_name, load_sitac
+
+
+def get_active_sitac(server: str) -> Sitac:
+    """Dependency injection of sitac by server name"""
+
+    server_path = get_server_path_by_name(server)
+
+    if not server_path.is_dir():
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"server {server} not found")
+
+    mission_path = detect_foothold_mission_path(server)
+
+    if not mission_path:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"mission not found for server {server}")
+
+    return load_sitac(mission_path)

--- a/app/foothold.py
+++ b/app/foothold.py
@@ -88,13 +88,15 @@ def load_sitac(file: Path) -> Sitac:
     zone_persistance = lua.globals().zonePersistance  # type: ignore
     zone_persistance_dict = lua_to_dict(zone_persistance)
 
-    return Sitac(**zone_persistance_dict, updated_at=file.stat().st_mtime)  # type: ignore
+    return Sitac(
+        **zone_persistance_dict,  # type: ignore
+        updated_at=datetime.fromtimestamp(file.stat().st_mtime)
+    )
 
 
 def detect_foothold_mission_path(server_name: str) -> Path | None:
 
     file_status = get_foothold_server_status_path(server_name)
-    print(file_status)
 
     if not file_status.is_file():
         return None

--- a/app/foothold_api_router.py
+++ b/app/foothold_api_router.py
@@ -1,0 +1,35 @@
+from typing import Annotated, Any
+from fastapi import APIRouter, Depends
+from app.dependencies import get_active_sitac
+from app.foothold import Sitac, list_servers
+from app.schemas import MapZone, Server
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[Server], description="List foothold servers")
+async def foothold_list_servers() -> Any:
+
+    return [Server.model_validate({"name": server}) for server in list_servers()]
+
+
+@router.get("/{server}/sitac", response_model=Sitac)
+async def foothold_get_sitac(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> Any:
+    return sitac
+
+
+@router.get("/{server}/map.json", response_model=list[MapZone])
+async def foothold_get_map_data(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> Any:
+
+    return [
+        MapZone.model_validate(
+            {
+                "name": zone_name,
+                "lat": zone.position.latitude,
+                "lon": zone.position.longitude,
+                "side": zone.side_str,
+                "color": zone.side_color
+            }
+        )
+        for zone_name, zone in sitac.zones.items() if zone.position
+    ]

--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -1,26 +1,11 @@
 from typing import Annotated
-from fastapi import APIRouter, Depends, Request, HTTPException, status
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
-from app.foothold import ZonePersistance, detect_foothold_mission_path, get_server_path_by_name, get_sitac_center, list_servers, load_sitac
+from app.foothold import Sitac, get_sitac_center, list_servers
 from app.templater import env
+from app.dependencies import get_active_sitac
 
 router = APIRouter()
-
-
-def get_active_sitac(server: str) -> ZonePersistance:
-    """Dependency injection of sitac by server name"""
-
-    server_path = get_server_path_by_name(server)
-
-    if not server_path.is_dir():
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"server {server} not found")
-
-    mission_path = detect_foothold_mission_path(server_path)
-
-    if not mission_path:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"mission not found for server {server}")
-
-    return load_sitac(mission_path)
 
 
 @router.get("", response_class=HTMLResponse)
@@ -38,7 +23,7 @@ async def foothold_servers(request: Request):
 
 
 @router.get("/sitac/{server}", response_class=HTMLResponse)
-async def foothold_sitac(request: Request, sitac: Annotated[ZonePersistance, Depends(get_active_sitac)]):
+async def foothold_sitac(request: Request, sitac: Annotated[Sitac, Depends(get_active_sitac)]):
 
     template = env.get_template("foothold/sitac.html")
     return template.render(
@@ -50,7 +35,7 @@ async def foothold_sitac(request: Request, sitac: Annotated[ZonePersistance, Dep
 
 
 @router.get("/map/{server}", response_class=HTMLResponse)
-async def foothold_map(request: Request, server: str, sitac: Annotated[ZonePersistance, Depends(get_active_sitac)]):
+async def foothold_map(request: Request, server: str, sitac: Annotated[Sitac, Depends(get_active_sitac)]):
 
     template = env.get_template("foothold/map.html")
     map_center = get_sitac_center(sitac)
@@ -63,21 +48,3 @@ async def foothold_map(request: Request, server: str, sitac: Annotated[ZonePersi
             "center": [map_center.latitude, map_center.longitude],
         }
     )
-
-
-@router.get("/map/{server}/data.json")
-async def foothold_map_data(request: Request, sitac: Annotated[ZonePersistance, Depends(get_active_sitac)]):
-
-    # sitac = load_sitac(FOOTHOLD_SITAC_PATH)  # todo use real data
-    zones: list[dict[str, str | float]] = [
-        {
-            "name": zone_name,
-            "lat": zone.position.latitude,
-            "lon": zone.position.longitude,
-            "side": zone.side_str,
-            "color": zone.side_color
-        }
-        for zone_name, zone in sitac.zones.items() if zone.position
-    ]
-
-    return zones

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ import uvicorn
 from fastapi.responses import HTMLResponse
 from fastapi import FastAPI, Request
 from app.config import get_config
+from app.foothold_api_router import router as foothold_api_router
 from app.foothold_router import router as foothold_router
 from app.templater import env
 
@@ -14,12 +15,13 @@ app = FastAPI(
 )
 
 
-@app.get("/", response_class=HTMLResponse)
+@app.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def home(request: Request):
     template = env.get_template("home.html")
     return template.render(request=request)
 
-app.include_router(foothold_router, prefix="/foothold", tags=["foothold"])
+app.include_router(foothold_router, prefix="/foothold", include_in_schema=False)
+app.include_router(foothold_api_router, prefix="/api/foothold", tags=["foothold"])
 
 if __name__ == "__main__":
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class Server(BaseModel):
+    name: str
+
+
+class MapZone(BaseModel):
+
+    name: str
+    lat: float
+    lon: float
+    side: str
+    color: str

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -28,7 +28,7 @@
         const zonesLayer = L.layerGroup().addTo(map);
 
         function loadData() {
-            fetch('{{ request.url_for("foothold_map_data", server=server) }}')
+            fetch('{{ request.url_for("foothold_get_map_data", server=server) }}')
                 .then(r => r.json())
                 .then(data => {
                     zonesLayer.clearLayers()

--- a/templates/foothold/sitac.html
+++ b/templates/foothold/sitac.html
@@ -155,7 +155,7 @@
                 </tr>
             </thead>
             <tbody>
-                {% for player, stats in sitac.playerStats.items() | sort(attribute='1.points', reverse=True) %}
+                {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
                 <tr>
                     <td>{{ player }}</td>
                     <td class="n">{{ stats.points | int }}</td>


### PR DESCRIPTION
## Summary by Sourcery

Add a structured JSON API for foothold SITAC and map data, refactor the data model to snake_case with timestamps, relocate dependency logic, and adjust routing and templates to match the new API.

New Features:
- Expose foothold server list, SITAC data, and map zone data via new JSON API endpoints under /api/foothold

Enhancements:
- Rename ZonePersistance model to Sitac, normalize field names to snake_case with Pydantic aliases, and add updated_at timestamp to SITAC loads
- Refactor detect_foothold_mission_path to use server status file and accept server name directly
- Extract get_active_sitac dependency into a separate module and streamline FastAPI router dependencies
- Hide HTML foothold endpoints from the OpenAPI schema and mount API routes under a dedicated prefix
- Update Jinja templates to use new snake_case model attributes and updated API route names