### PR TITLE
add remaining units on zones, circle size depends on zone level

### DIFF
--- a/app/foothold.py
+++ b/app/foothold.py
@@ -21,7 +21,7 @@ class Zone(BaseModel):
     active: bool
     destroyed: dict[int, str] | list[str] | dict
     extra_upgrade: dict = Field(alias="extraUpgrade")
-    remainingUnits: dict[int, dict[int, str]] | dict
+    remaining_units: dict[int, dict[int, str]] | dict = Field(alias="remainingUnits")
     first_capture_by_red: bool = Field(alias="firstCaptureByRed")
     level: int
     wasBlue: bool
@@ -43,6 +43,10 @@ class Zone(BaseModel):
         elif self.side == 2:
             return "blue"
         return "neutral"
+
+    @property
+    def total_units(self) -> int:
+        return sum([len(group_units) for group_units in self.remaining_units.values()])
 
 
 class PlayerStats(BaseModel):

--- a/app/foothold_api_router.py
+++ b/app/foothold_api_router.py
@@ -28,7 +28,9 @@ async def foothold_get_map_data(sitac: Annotated[Sitac, Depends(get_active_sitac
                 "lat": zone.position.latitude,
                 "lon": zone.position.longitude,
                 "side": zone.side_str,
-                "color": zone.side_color
+                "color": zone.side_color,
+                "units": zone.total_units,
+                "level": zone.level
             }
         )
         for zone_name, zone in sitac.zones.items() if zone.position

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -12,3 +12,5 @@ class MapZone(BaseModel):
     lon: float
     side: str
     color: str
+    units: int
+    level: int

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -18,10 +18,11 @@
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script>
         map_center = JSON.parse('{{ center }}')
-        const map = L.map('map').setView(map_center, 7);
+        const map = L.map('map').setView(map_center, 8);
 
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            maxZoom: 19,
+            minZoom: 8,
+            maxZoom: 10,
             attribution: '&copy; OpenStreetMap'
         }).addTo(map);
 
@@ -39,10 +40,13 @@
                             color: p.color,
                             fillColor: p.color,
                             fillOpacity: 0.3,
-                            radius: 10000
-                        }).addTo(zonesLayer)
-                            .bindPopup(p.name || `${p.lat}, ${p.lon}`);
-                        ;
+                            radius: Math.min(20000,Math.max(2000, 2000 * p.level)),
+                        }).addTo(zonesLayer);
+
+                        circle.bindPopup(p.name || `${p.lat}, ${p.lon}`);
+                        if (p.units > 0) {
+                            circle.bindTooltip(p.units + " units", { permanent: true, position: "right", direction: "top" });
+                        }
 
                     });
                 })


### PR DESCRIPTION
## Summary by Sourcery

Enable dynamic circle sizing and unit displays on the foothold map, and tighten map zoom settings.

New Features:
- Show remaining unit counts on zone circles as permanent tooltips.
- Include units and level fields in the map API response and schema.

Enhancements:
- Compute total_units in the Zone model and rename remainingUnits to remaining_units for consistency.
- Scale circle radius based on zone level with configurable min/max bounds.
- Adjust initial map zoom to 8 and limit tile layer zoom between 8 and 10.