### PR TITLE
add custom url tiles

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,10 +18,16 @@ class DcsConfig(BaseModel):
     saved_games: str = "var"  # "DCS Saved Games Path"
 
 
+class MapConfig(BaseModel):
+
+    url_tiles: str = "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+
+
 class AppConfig(BaseModel):
 
     web: Annotated[WebConfig, Field(default_factory=WebConfig)]
     dcs: Annotated[DcsConfig, Field(default_factory=DcsConfig)]
+    map: Annotated[MapConfig, Field(default_factory=MapConfig)]
 
 
 def load_config_str(raw_config: dict[Any, Any]) -> AppConfig:

--- a/app/foothold.py
+++ b/app/foothold.py
@@ -34,7 +34,7 @@ class Zone(BaseModel):
             return "red"
         elif self.side == 2:
             return "blue"
-        return "gray"
+        return "lightgray"
 
     @property
     def side_str(self) -> str:

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -16,3 +16,11 @@ web:
 
 dcs:
     saved_games: "C:\\Users\\veaf\\Saved Games" # !! update your setup
+
+map:
+
+    # openstreetmap
+    # url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+
+    # arcgis (default)
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -20,9 +20,9 @@
         map_center = JSON.parse('{{ center }}')
         const map = L.map('map').setView(map_center, 8);
 
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer('{{ config.map.url_tiles }}', {
             minZoom: 8,
-            maxZoom: 10,
+            maxZoom: 11,
             attribution: '&copy; OpenStreetMap'
         }).addTo(map);
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable map tile URL and refine map rendering settings and default side color.

New Features:
- Add MapConfig.url_tiles for specifying a custom map tile URL in the application config

Enhancements:
- Use the custom map tile URL in the Leaflet map template instead of the hardcoded OpenStreetMap URL
- Increase the map's maxZoom level from 10 to 11
- Change the default Foothold side color from gray to lightgray

Chores:
- Update config.yml.dist to include the new map configuration section