### PR TITLE
add config of min_zoom and max_zoom

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,9 @@ class MapConfig(BaseModel):
 
     url_tiles: str = "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
 
+    min_zoom: int = 8
+    max_zoom: int = 11
+
 
 class AppConfig(BaseModel):
 

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -24,3 +24,9 @@ map:
 
     # arcgis (default)
     url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+
+    # minimum zoom level
+    # min_zoom: 8
+
+    # maximum zoom level
+    # max_zoom: 11

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -17,12 +17,13 @@
     <div id="map"></div>
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script>
-        map_center = JSON.parse('{{ center }}')
+        map_center = JSON.parse('{{ center }}');
+        map_options = JSON.parse('{{ config.map.model_dump() | tojson }}');
         const map = L.map('map').setView(map_center, 8);
 
-        L.tileLayer('{{ config.map.url_tiles }}', {
-            minZoom: 8,
-            maxZoom: 11,
+        L.tileLayer(map_options.url_tiles, {
+            minZoom: map_options.min_zoom,
+            maxZoom: map_options.max_zoom,
             attribution: '&copy; OpenStreetMap'
         }).addTo(map);
 


### PR DESCRIPTION
## Summary by Sourcery

Enable dynamic configuration of Leaflet map options by introducing min_zoom and max_zoom settings in the backend and applying them in the map template.

New Features:
- Add min_zoom and max_zoom parameters to MapConfig to enable configurable zoom levels

Enhancements:
- Pass full map configuration to the frontend and replace hardcoded tile URL and zoom bounds with dynamic values