### PR TITLE
hidden groups and hidden objectives are not displayed on the map anymore

### DIFF
--- a/app/foothold.py
+++ b/app/foothold.py
@@ -27,6 +27,7 @@ class Zone(BaseModel):
     wasBlue: bool
     triggers: dict[str, int]
     position: Position = Field(alias="lat_long")
+    hidden: bool = False
 
     @property
     def side_color(self) -> str:

--- a/app/foothold_api_router.py
+++ b/app/foothold_api_router.py
@@ -33,5 +33,5 @@ async def foothold_get_map_data(sitac: Annotated[Sitac, Depends(get_active_sitac
                 "level": zone.level
             }
         )
-        for zone_name, zone in sitac.zones.items() if zone.position
+        for zone_name, zone in sitac.zones.items() if zone.position and not zone.hidden
     ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -42,6 +42,17 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.31.0)"]
 
 [[package]]
+name = "certifi"
+version = "2025.11.12"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b"},
+    {file = "certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316"},
+]
+
+[[package]]
 name = "click"
 version = "8.3.0"
 description = "Composable command line interface toolkit"
@@ -98,6 +109,51 @@ files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
@@ -708,4 +764,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e0f46a97c77f9fe675fb0080fcee0a9241e3f3ad210c8ac3f587d88e91a2651f"
+content-hash = "0986226deedc0487bcdd0f3063bc96ba5c8ba075aae11578a864c6f8b99938fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pyyaml = "^6.0.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.1"
+httpx = "^0.28.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/fixtures/test_hidden/Missions/Saves/foothold.status
+++ b/tests/fixtures/test_hidden/Missions/Saves/foothold.status
@@ -1,0 +1,1 @@
+tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua

--- a/tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua
+++ b/tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua
@@ -1,0 +1,11 @@
+zonePersistance = {}
+zonePersistance['zones'] = {
+    ['VisibleZone1']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ [1]={ [1]='T-72B3' } },['lat_long']={ ['longitude']=36.0,['latitude']=33.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['VisibleZone2']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['hidden']=false,['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=37.0,['latitude']=34.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=2,['wasBlue']=true,['triggers']={ ['missioncompleted']=1 } },
+    ['HiddenZone1']={ ['upgradesUsed']=0,['side']=0,['active']=false,['destroyed']={ },['hidden']=true,['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=38.0,['latitude']=35.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=0,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['HiddenZone2']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['hidden']=true,['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=39.0,['latitude']=36.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=3,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } }
+}
+zonePersistance['playerStats'] = { }
+zonePersistance['accounts'] = { [1]=1000,[2]=2000 }
+zonePersistance['shops'] = { [1]={ },[2]={ } }
+zonePersistance['customFlags'] = { }

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_map_data_excludes_hidden_zones(client):
+    response = client.get("/api/foothold/test_hidden/map.json")
+    assert response.status_code == 200
+
+    zones = response.json()
+    zone_names = [z["name"] for z in zones]
+
+    assert "VisibleZone1" in zone_names
+    assert "VisibleZone2" in zone_names
+    assert "HiddenZone1" not in zone_names
+    assert "HiddenZone2" not in zone_names
+    assert len(zones) == 2
+
+
+def test_sitac_includes_hidden_zones(client):
+    response = client.get("/api/foothold/test_hidden/sitac")
+    assert response.status_code == 200
+
+    sitac = response.json()
+    zones = sitac["zones"]
+
+    assert "VisibleZone1" in zones
+    assert "VisibleZone2" in zones
+    assert "HiddenZone1" in zones
+    assert "HiddenZone2" in zones
+    assert len(zones) == 4
+
+
+def test_sitac_hidden_field_values(client):
+    response = client.get("/api/foothold/test_hidden/sitac")
+    assert response.status_code == 200
+
+    zones = response.json()["zones"]
+
+    assert zones["VisibleZone1"]["hidden"] is False
+    assert zones["VisibleZone2"]["hidden"] is False
+    assert zones["HiddenZone1"]["hidden"] is True
+    assert zones["HiddenZone2"]["hidden"] is True

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,11 +1,25 @@
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app
+from app.config import get_config
 
 
 @pytest.fixture
 def client():
+    get_config.cache_clear()
     return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def override_config(monkeypatch):
+    monkeypatch.setattr("app.config.get_config", lambda: type("AppConfig", (), {
+        "dcs": type("DcsConfig", (), {"saved_games": "tests/fixtures"})(),
+        "web": type("WebConfig", (), {"title": "Test"})(),
+        "map": type("MapConfig", (), {"url_tiles": "", "min_zoom": 8, "max_zoom": 11})(),
+    })())
+    monkeypatch.setattr("app.foothold.get_config", lambda: type("AppConfig", (), {
+        "dcs": type("DcsConfig", (), {"saved_games": "tests/fixtures"})(),
+    })())
 
 
 def test_map_data_excludes_hidden_zones(client):

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -38,7 +38,7 @@ def test_zone_hidden_default(base_zone_data):
 
 
 def test_load_sitac_with_hidden_zones():
-    lua_path = Path("var/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+    lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
     sitac = load_sitac(lua_path)
 
     assert "VisibleZone1" in sitac.zones
@@ -53,7 +53,7 @@ def test_load_sitac_with_hidden_zones():
 
 
 def test_load_sitac_hidden_zones_count():
-    lua_path = Path("var/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+    lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
     sitac = load_sitac(lua_path)
 
     visible_zones = [z for z in sitac.zones.values() if not z.hidden]

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import pytest
+from app.foothold import Zone, Position, load_sitac
+
+
+@pytest.fixture
+def base_zone_data():
+    return {
+        "upgradesUsed": 0,
+        "side": 1,
+        "active": True,
+        "destroyed": {},
+        "extraUpgrade": {},
+        "remainingUnits": {},
+        "firstCaptureByRed": True,
+        "level": 1,
+        "wasBlue": False,
+        "triggers": {"missioncompleted": 0},
+        "lat_long": {"latitude": 33.0, "longitude": 36.0, "altitude": 0},
+    }
+
+
+def test_zone_hidden_true(base_zone_data):
+    base_zone_data["hidden"] = True
+    zone = Zone.model_validate(base_zone_data)
+    assert zone.hidden is True
+
+
+def test_zone_hidden_false(base_zone_data):
+    base_zone_data["hidden"] = False
+    zone = Zone.model_validate(base_zone_data)
+    assert zone.hidden is False
+
+
+def test_zone_hidden_default(base_zone_data):
+    zone = Zone.model_validate(base_zone_data)
+    assert zone.hidden is False
+
+
+def test_load_sitac_with_hidden_zones():
+    lua_path = Path("var/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+    sitac = load_sitac(lua_path)
+
+    assert "VisibleZone1" in sitac.zones
+    assert "VisibleZone2" in sitac.zones
+    assert "HiddenZone1" in sitac.zones
+    assert "HiddenZone2" in sitac.zones
+
+    assert sitac.zones["VisibleZone1"].hidden is False
+    assert sitac.zones["VisibleZone2"].hidden is False
+    assert sitac.zones["HiddenZone1"].hidden is True
+    assert sitac.zones["HiddenZone2"].hidden is True
+
+
+def test_load_sitac_hidden_zones_count():
+    lua_path = Path("var/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+    sitac = load_sitac(lua_path)
+
+    visible_zones = [z for z in sitac.zones.values() if not z.hidden]
+    hidden_zones = [z for z in sitac.zones.values() if z.hidden]
+
+    assert len(visible_zones) == 2
+    assert len(hidden_zones) == 2


### PR DESCRIPTION
## Summary by Sourcery

Hide hidden foothold zones from the map API response while preserving them in SITAC data and validating the new behavior with tests.

New Features:
- Introduce a hidden flag on foothold zones to control their visibility on the map endpoint.

Bug Fixes:
- Exclude hidden zones from the map JSON output while keeping them in the SITAC payload.

Build:
- Add httpx as a development dependency for HTTP-related testing utilities.

Tests:
- Add unit tests to verify Zone.hidden defaults and SITAC loading of hidden and visible zones.
- Add integration tests to ensure the map endpoint omits hidden zones while SITAC responses include them with correct hidden values.