### PR TITLE
add refresh timer and state

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 
@@ -14,3 +15,9 @@ class MapZone(BaseModel):
     color: str
     units: int
     level: int
+
+
+class MapData(BaseModel):
+    updated_at: datetime
+    age_seconds: float
+    zones: list[MapZone]

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -10,12 +10,70 @@
             height: 100vh;
             width: 100%;
         }
+
+        #freshness-widget {
+            position: fixed;
+            bottom: 10px;
+            right: 10px;
+            padding: 8px 12px;
+            border-radius: 8px;
+            background-color: #2ecc71;
+            color: white;
+            font-family: sans-serif;
+            font-size: 14px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+        }
+
+        #freshness-widget.fresh { background-color: #2ecc71; }
+        #freshness-widget.stale { background-color: #e74c3c; }
+        #freshness-widget.disconnected { background-color: #555; }
+
+        #freshness-widget:hover .tooltip {
+            visibility: visible;
+            opacity: 1;
+        }
+
+        .tooltip {
+            visibility: hidden;
+            opacity: 0;
+            position: absolute;
+            bottom: 100%;
+            right: 0;
+            margin-bottom: 8px;
+            padding: 8px 12px;
+            background-color: rgba(0, 0, 0, 0.85);
+            color: white;
+            font-size: 12px;
+            border-radius: 6px;
+            white-space: nowrap;
+            transition: opacity 0.2s;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+        }
+
+        .tooltip::after {
+            content: '';
+            position: absolute;
+            top: 100%;
+            right: 12px;
+            border-width: 6px;
+            border-style: solid;
+            border-color: rgba(0, 0, 0, 0.85) transparent transparent transparent;
+        }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 </head>
 
 <body>
     <div id="map"></div>
+    <div id="freshness-widget" class="fresh">
+        <span id="freshness-icon">🕐</span>
+        <span id="countdown">30s</span>
+        <span class="tooltip" id="freshness-tooltip">Refresh in 30s</span>
+    </div>
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script>
         map_center = JSON.parse('{{ center }}');
@@ -30,14 +88,53 @@
 
         const zonesLayer = L.layerGroup().addTo(map);
 
+        // Freshness widget state
+        const REFRESH_INTERVAL = 30;
+        let nextRefresh = REFRESH_INTERVAL;
+        let dataAgeSeconds = 0;
+        let isConnected = true;
+
+        function updateFreshnessWidget() {
+            const widget = document.getElementById('freshness-widget');
+            const icon = document.getElementById('freshness-icon');
+            const countdown = document.getElementById('countdown');
+            const tooltip = document.getElementById('freshness-tooltip');
+
+            widget.classList.remove('fresh', 'stale', 'disconnected');
+
+            if (!isConnected) {
+                widget.classList.add('disconnected');
+                icon.textContent = '⚠️';
+                countdown.textContent = 'Offline';
+                tooltip.textContent = 'Connection to server lost';
+            } else if (dataAgeSeconds < 60) {
+                widget.classList.add('fresh');
+                icon.textContent = '🕐';
+                countdown.textContent = nextRefresh + 's';
+                tooltip.textContent = `Data up to date (${Math.round(dataAgeSeconds)}s) • Refresh in ${nextRefresh}s`;
+            } else {
+                widget.classList.add('stale');
+                icon.textContent = '🕐';
+                countdown.textContent = nextRefresh + 's';
+                const minutes = Math.floor(dataAgeSeconds / 60);
+                tooltip.textContent = `Stale data (${minutes}min) • Refresh in ${nextRefresh}s`;
+            }
+        }
+
         function loadData() {
             fetch('{{ request.url_for("foothold_get_map_data", server=server) }}')
-                .then(r => r.json())
+                .then(r => {
+                    if (!r.ok) throw new Error('API error');
+                    return r.json();
+                })
                 .then(data => {
-                    zonesLayer.clearLayers()
-                    data.forEach(p => {
+                    isConnected = true;
+                    dataAgeSeconds = data.age_seconds;
+                    nextRefresh = REFRESH_INTERVAL;
+                    updateFreshnessWidget();
 
-
+                    zonesLayer.clearLayers();
+                    data.zones.forEach(p => {
                         var circle = L.circle([p.lat, p.lon], {
                             color: p.color,
                             fillColor: p.color,
@@ -49,14 +146,29 @@
                         if (p.units > 0) {
                             circle.bindTooltip(p.units + " units", { permanent: true, position: "right", direction: "top" });
                         }
-
                     });
                 })
-                .catch(console.error);
+                .catch(error => {
+                    console.error(error);
+                    isConnected = false;
+                    updateFreshnessWidget();
+                });
         }
 
+        // Countdown timer - updates every second
+        setInterval(() => {
+            if (nextRefresh > 0) {
+                nextRefresh--;
+                dataAgeSeconds++;
+            }
+            if (nextRefresh <= 0) {
+                nextRefresh = REFRESH_INTERVAL;
+            }
+            updateFreshnessWidget();
+        }, 1000);
+
         loadData(); // initial load
-        setInterval(loadData, 30000); // refresh every x ms
+        setInterval(loadData, REFRESH_INTERVAL * 1000); // refresh every REFRESH_INTERVAL seconds
     </script>
 </body>
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -26,7 +26,12 @@ def test_map_data_excludes_hidden_zones(client):
     response = client.get("/api/foothold/test_hidden/map.json")
     assert response.status_code == 200
 
-    zones = response.json()
+    data = response.json()
+    assert "updated_at" in data
+    assert "age_seconds" in data
+    assert "zones" in data
+
+    zones = data["zones"]
     zone_names = [z["name"] for z in zones]
 
     assert "VisibleZone1" in zone_names


### PR DESCRIPTION
## Summary by Sourcery

Add a map data freshness indicator with timer and connection state, and extend the map API to return metadata about data recency.

New Features:
- Display a freshness widget on the foothold map showing time until next refresh, data age, and connection status.
- Expose map metadata (updated_at, age_seconds, and zones) via a new MapData API schema instead of returning a bare list of zones.

Enhancements:
- Add client-side state management for refresh intervals and connectivity to keep the foothold map UI in sync with server updates.

Tests:
- Extend the foothold map API integration test to validate the new MapData envelope and its fields in the JSON response.