### PR TITLE
add alternatives tiles

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,9 +18,16 @@ class DcsConfig(BaseModel):
     saved_games: str = "var"  # "DCS Saved Games Path"
 
 
+class TileLayerConfig(BaseModel):
+
+    name: str
+    url: str
+
+
 class MapConfig(BaseModel):
 
     url_tiles: str = "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+    alternative_tiles: Annotated[list[TileLayerConfig], Field(default_factory=list)]
 
     min_zoom: int = 8
     max_zoom: int = 11

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -20,10 +20,17 @@ dcs:
 map:
 
     # openstreetmap
-    # url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    # url_tiles: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
 
     # arcgis (default)
-    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+    url_tiles: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+
+    # alternative tile layers (optional, adds a layer switcher control)
+    # alternative_tiles:
+    #   - name: "OpenStreetMap"
+    #     url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    #   - name: "Terrain"
+    #     url: "https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg"
 
     # minimum zoom level
     # min_zoom: 8

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -6,6 +6,11 @@
     <title>{{ config.web.title }} - Map</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+        }
+
         #map {
             height: 100vh;
             width: 100%;
@@ -80,11 +85,27 @@
         map_options = JSON.parse('{{ config.map.model_dump() | tojson }}');
         const map = L.map('map').setView(map_center, 8);
 
-        L.tileLayer(map_options.url_tiles, {
+        // Base tile layers
+        const baseLayers = {};
+        const defaultLayer = L.tileLayer(map_options.url_tiles, {
             minZoom: map_options.min_zoom,
             maxZoom: map_options.max_zoom,
             attribution: '&copy; OpenStreetMap'
-        }).addTo(map);
+        });
+        baseLayers['Default'] = defaultLayer;
+        defaultLayer.addTo(map);
+
+        // Alternative tile layers
+        if (map_options.alternative_tiles && map_options.alternative_tiles.length > 0) {
+            map_options.alternative_tiles.forEach(tile => {
+                baseLayers[tile.name] = L.tileLayer(tile.url, {
+                    minZoom: map_options.min_zoom,
+                    maxZoom: map_options.max_zoom,
+                    attribution: '&copy; OpenStreetMap'
+                });
+            });
+            L.control.layers(baseLayers, null, { position: 'topright' }).addTo(map);
+        }
 
         const zonesLayer = L.layerGroup().addTo(map);
 


### PR DESCRIPTION
## Summary by Sourcery

Add configurable alternative map tile layers and expose them in the map UI.

New Features:
- Allow configuration of multiple named alternative map tile providers via map configuration.
- Expose a layer switcher in the map view to toggle between default and alternative tile layers.

Tests:
- Add unit tests covering default map config, custom tile URL, alternative tile definitions including env expansion, zoom levels, and full map configuration.