### PR TITLE
add player rank position

### DIFF
--- a/templates/foothold/partials/players.html
+++ b/templates/foothold/partials/players.html
@@ -62,6 +62,7 @@
 <table class="modal-table">
     <thead>
         <tr>
+            <th>#</th>
             <th>Player</th>
             <th>Points</th>
             <th>Deaths</th>
@@ -74,6 +75,7 @@
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
         <tr>
+            <td class="n">{{ loop.index }}</td>
             <td>{{ player }}</td>
             <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.deaths }}</td>
@@ -84,7 +86,7 @@
         </tr>
         {% else %}
         <tr>
-            <td colspan="7" style="text-align: center; color: #5a6270;">No player data available</td>
+            <td colspan="8" style="text-align: center; color: #5a6270;">No player data available</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/templates/foothold/sitac.html
+++ b/templates/foothold/sitac.html
@@ -145,6 +145,7 @@
         <table>
             <thead>
                 <tr>
+                    <th>#</th>
                     <th>Player</th>
                     <th>Points</th>
                     <th>Deaths</th>
@@ -157,6 +158,7 @@
             <tbody>
                 {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
                 <tr>
+                    <td class="n">{{ loop.index }}</td>
                     <td>{{ player }}</td>
                     <td class="n">{{ stats.points | int }}</td>
                     <td class="n">{{ stats.deaths }}</td>


### PR DESCRIPTION
## Summary by Sourcery

Display player rank positions in player stats tables.

New Features:
- Show a numeric rank column for players in the player rankings and player stats tables.

Enhancements:
- Adjust the "no player data" row to span the new rank column.