### PR TITLE
Feature/39 add campaign progress information

### DIFF
--- a/app/foothold.py
+++ b/app/foothold.py
@@ -71,6 +71,21 @@ class Sitac(BaseModel):
     zones: dict[str, Zone]
     player_stats: dict[str, PlayerStats] = Field(alias="playerStats")
 
+    @property
+    def campaign_progress(self) -> float:
+        """Retourne le pourcentage de progression de la campagne (0-100).
+
+        La progression est calculée comme:
+        (zones_visibles - zones_rouges) / zones_visibles * 100
+
+        Les zones cachées (hidden=True) sont exclues du calcul.
+        """
+        visible_zones = [z for z in self.zones.values() if not z.hidden]
+        if not visible_zones:
+            return 0.0
+        red_zones = sum(1 for z in visible_zones if z.side == 1)
+        return (len(visible_zones) - red_zones) / len(visible_zones) * 100
+
 
 def lua_to_dict(lua_table: Any) -> dict[Any, Any] | None:
     if lua_table is None:

--- a/app/foothold.py
+++ b/app/foothold.py
@@ -73,12 +73,12 @@ class Sitac(BaseModel):
 
     @property
     def campaign_progress(self) -> float:
-        """Retourne le pourcentage de progression de la campagne (0-100).
+        """Return the campaign progress percentage (0-100).
 
-        La progression est calculée comme:
-        (zones_visibles - zones_rouges) / zones_visibles * 100
+        Progress is calculated as:
+        (visible_zones - red_zones) / visible_zones * 100
 
-        Les zones cachées (hidden=True) sont exclues du calcul.
+        Hidden zones (hidden=True) are excluded from the calculation.
         """
         visible_zones = [z for z in self.zones.values() if not z.hidden]
         if not visible_zones:

--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -59,6 +59,7 @@ async def foothold_map(request: Request, server: str, sitac: Annotated[Sitac, De
             "sitac": sitac,
             "server": server,
             "center": [map_center.latitude, map_center.longitude],
+            "progress": sitac.campaign_progress,
         }
     )
 
@@ -72,4 +73,4 @@ async def foothold_players_modal(sitac: Annotated[Sitac, Depends(get_active_sita
 @router.get("/map/{server}/zones", response_class=HTMLResponse)
 async def foothold_zones_modal(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> str:
     template = env.get_template("foothold/partials/zones.html")
-    return template.render({"sitac": sitac})
+    return template.render({"sitac": sitac, "progress": sitac.campaign_progress})

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -35,6 +35,20 @@
         .navbar-brand {
             font-weight: 600;
             font-size: 16px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .navbar-progress {
+            display: inline-flex;
+            align-items: center;
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 13px;
+            font-weight: 600;
+            background: linear-gradient(145deg, #4263eb 0%, #3451c9 100%);
+            box-shadow: 0 2px 8px rgba(66, 99, 235, 0.4);
         }
 
         .navbar-links {
@@ -226,7 +240,10 @@
 <body>
     <!-- Navbar -->
     <nav class="navbar">
-        <span class="navbar-brand"><i class="fa-solid fa-server"></i> {{ server }}</span>
+        <span class="navbar-brand">
+            <span><i class="fa-solid fa-server"></i> {{ server }}</span>
+            <span class="navbar-progress"><i class="fa-solid fa-flag"></i> {{ "%.0f"|format(progress) }}%</span>
+        </span>
         <div class="navbar-links">
             <a href="#" onclick="openModal('players'); return false;"><i class="fa-solid fa-ranking-star"></i> Player Rankings</a>
             <a href="#" onclick="openModal('zones'); return false;"><i class="fa-solid fa-bullseye"></i> Objectives</a>

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -35,9 +35,6 @@
         .navbar-brand {
             font-weight: 600;
             font-size: 16px;
-            display: flex;
-            align-items: center;
-            gap: 12px;
         }
 
         .navbar-progress {
@@ -240,13 +237,11 @@
 <body>
     <!-- Navbar -->
     <nav class="navbar">
-        <span class="navbar-brand">
-            <span><i class="fa-solid fa-server"></i> {{ server }}</span>
-            <span class="navbar-progress"><i class="fa-solid fa-flag"></i> {{ "%.0f"|format(progress) }}%</span>
-        </span>
+        <span class="navbar-brand"><i class="fa-solid fa-server"></i> {{ server }}</span>
         <div class="navbar-links">
             <a href="#" onclick="openModal('players'); return false;"><i class="fa-solid fa-ranking-star"></i> Player Rankings</a>
             <a href="#" onclick="openModal('zones'); return false;"><i class="fa-solid fa-bullseye"></i> Objectives</a>
+            <span class="navbar-progress"><i class="fa-solid fa-flag"></i> {{ "%.0f"|format(progress) }}%</span>
             <a href="{{ request.url_for('foothold_servers') }}"><i class="fa-solid fa-list"></i> Servers</a>
         </div>
     </nav>

--- a/templates/foothold/partials/zones.html
+++ b/templates/foothold/partials/zones.html
@@ -136,6 +136,43 @@
         padding: 40px 20px;
     }
 
+    /* Modal header (fixed) */
+    .modal-header-fixed {
+        flex-shrink: 0;
+    }
+
+    /* Scrollable tab content */
+    .tab-content-wrapper {
+        flex: 1;
+        overflow-y: auto;
+        min-height: 0;
+    }
+
+    .tab-content-wrapper::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    .tab-content-wrapper::-webkit-scrollbar-track {
+        background: rgba(255, 255, 255, 0.05);
+        border-radius: 4px;
+    }
+
+    .tab-content-wrapper::-webkit-scrollbar-thumb {
+        background: rgba(66, 99, 235, 0.3);
+        border-radius: 4px;
+    }
+
+    .tab-content-wrapper::-webkit-scrollbar-thumb:hover {
+        background: rgba(66, 99, 235, 0.5);
+    }
+
+    /* Container flex layout */
+    .zones-container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
     /* Progress bar */
     .progress-container {
         margin-bottom: 24px;
@@ -189,31 +226,35 @@
     {% endif %}
 {% endfor %}
 
-<h2>Objectives</h2>
+<div class="zones-container">
+    <div class="modal-header-fixed">
+        <h2>Objectives</h2>
 
-<div class="progress-container">
-    <div class="progress-header">
-        <span class="progress-label">Campaign Progress</span>
-        <span class="progress-value">{{ "%.0f"|format(progress) }}%</span>
+        <div class="progress-container">
+            <div class="progress-header">
+                <span class="progress-label">Campaign Progress</span>
+                <span class="progress-value">{{ "%.0f"|format(progress) }}%</span>
+            </div>
+            <div class="progress-bar">
+                <div class="progress-fill" style="width: {{ progress }}%"></div>
+            </div>
+        </div>
+
+        <div class="tabs">
+            <button class="tab-btn blue active" onclick="showTab('blue')">
+                Blue <span class="tab-badge">{{ blue_zones | length }}</span>
+            </button>
+            <button class="tab-btn neutral" onclick="showTab('neutral')">
+                Neutral <span class="tab-badge">{{ neutral_zones | length }}</span>
+            </button>
+            <button class="tab-btn red" onclick="showTab('red')">
+                Red <span class="tab-badge">{{ red_zones | length }}</span>
+            </button>
+        </div>
     </div>
-    <div class="progress-bar">
-        <div class="progress-fill" style="width: {{ progress }}%"></div>
-    </div>
-</div>
 
-<div class="tabs">
-    <button class="tab-btn blue active" onclick="showTab('blue')">
-        Blue <span class="tab-badge">{{ blue_zones | length }}</span>
-    </button>
-    <button class="tab-btn neutral" onclick="showTab('neutral')">
-        Neutral <span class="tab-badge">{{ neutral_zones | length }}</span>
-    </button>
-    <button class="tab-btn red" onclick="showTab('red')">
-        Red <span class="tab-badge">{{ red_zones | length }}</span>
-    </button>
-</div>
-
-<div id="tab-blue" class="tab-content active">
+    <div class="tab-content-wrapper">
+        <div id="tab-blue" class="tab-content active">
     {% if blue_zones %}
     <table class="modal-table">
         <thead>
@@ -292,6 +333,8 @@
     {% else %}
     <div class="empty-state">No red zones</div>
     {% endif %}
+        </div>
+    </div>
 </div>
 
 <script>

--- a/templates/foothold/partials/zones.html
+++ b/templates/foothold/partials/zones.html
@@ -135,6 +135,44 @@
         color: #5a6270;
         padding: 40px 20px;
     }
+
+    /* Progress bar */
+    .progress-container {
+        margin-bottom: 24px;
+    }
+
+    .progress-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+    }
+
+    .progress-label {
+        font-size: 14px;
+        color: #c9cdd4;
+        font-weight: 500;
+    }
+
+    .progress-value {
+        font-size: 14px;
+        color: #60a5fa;
+        font-weight: 600;
+    }
+
+    .progress-bar {
+        height: 12px;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
+    .progress-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #4263eb 0%, #60a5fa 100%);
+        border-radius: 6px;
+        transition: width 0.3s ease;
+    }
 </style>
 
 {% set blue_zones = [] %}
@@ -152,6 +190,16 @@
 {% endfor %}
 
 <h2>Objectives</h2>
+
+<div class="progress-container">
+    <div class="progress-header">
+        <span class="progress-label">Campaign Progress</span>
+        <span class="progress-value">{{ "%.0f"|format(progress) }}%</span>
+    </div>
+    <div class="progress-bar">
+        <div class="progress-fill" style="width: {{ progress }}%"></div>
+    </div>
+</div>
 
 <div class="tabs">
     <button class="tab-btn blue active" onclick="showTab('blue')">

--- a/tests/fixtures/test_progress/foothold_all_blue.lua
+++ b/tests/fixtures/test_progress/foothold_all_blue.lua
@@ -1,0 +1,8 @@
+zonePersistance = {}
+zonePersistance['zones'] = {
+    ['Zone1']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=36.0,['latitude']=33.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } },
+    ['Zone2']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=37.0,['latitude']=34.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } },
+    ['Zone3']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=38.0,['latitude']=35.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } },
+    ['Zone4']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=39.0,['latitude']=36.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } }
+}
+zonePersistance['playerStats'] = { }

--- a/tests/fixtures/test_progress/foothold_all_red.lua
+++ b/tests/fixtures/test_progress/foothold_all_red.lua
@@ -1,0 +1,8 @@
+zonePersistance = {}
+zonePersistance['zones'] = {
+    ['Zone1']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=36.0,['latitude']=33.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['Zone2']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=37.0,['latitude']=34.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['Zone3']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=38.0,['latitude']=35.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['Zone4']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=39.0,['latitude']=36.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } }
+}
+zonePersistance['playerStats'] = { }

--- a/tests/fixtures/test_progress/foothold_empty.lua
+++ b/tests/fixtures/test_progress/foothold_empty.lua
@@ -1,0 +1,3 @@
+zonePersistance = {}
+zonePersistance['zones'] = { }
+zonePersistance['playerStats'] = { }

--- a/tests/fixtures/test_progress/foothold_mixed.lua
+++ b/tests/fixtures/test_progress/foothold_mixed.lua
@@ -1,0 +1,8 @@
+zonePersistance = {}
+zonePersistance['zones'] = {
+    ['RedZone1']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=36.0,['latitude']=33.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['RedZone2']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=37.0,['latitude']=34.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['BlueZone1']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=38.0,['latitude']=35.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } },
+    ['BlueZone2']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=39.0,['latitude']=36.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } }
+}
+zonePersistance['playerStats'] = { }

--- a/tests/fixtures/test_progress/foothold_with_neutral.lua
+++ b/tests/fixtures/test_progress/foothold_with_neutral.lua
@@ -1,0 +1,7 @@
+zonePersistance = {}
+zonePersistance['zones'] = {
+    ['RedZone']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=36.0,['latitude']=33.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['BlueZone']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=37.0,['latitude']=34.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } },
+    ['NeutralZone']={ ['upgradesUsed']=0,['side']=0,['active']=false,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=38.0,['latitude']=35.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=0,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } }
+}
+zonePersistance['playerStats'] = { }

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -64,3 +64,51 @@ def test_load_sitac_hidden_zones_count() -> None:
 
     assert len(visible_zones) == 2
     assert len(hidden_zones) == 2
+
+
+# Campaign progress tests
+
+
+def test_sitac_campaign_progress_all_red() -> None:
+    """100% rouge = 0% progression"""
+    lua_path = Path("tests/fixtures/test_progress/foothold_all_red.lua")
+    sitac = load_sitac(lua_path)
+    assert sitac.campaign_progress == 0.0
+
+
+def test_sitac_campaign_progress_all_blue() -> None:
+    """100% bleu = 100% progression"""
+    lua_path = Path("tests/fixtures/test_progress/foothold_all_blue.lua")
+    sitac = load_sitac(lua_path)
+    assert sitac.campaign_progress == 100.0
+
+
+def test_sitac_campaign_progress_mixed() -> None:
+    """2 rouges + 2 bleus = 50% progression"""
+    lua_path = Path("tests/fixtures/test_progress/foothold_mixed.lua")
+    sitac = load_sitac(lua_path)
+    assert sitac.campaign_progress == 50.0
+
+
+def test_sitac_campaign_progress_with_neutral() -> None:
+    """Les zones neutres comptent comme non-rouges"""
+    lua_path = Path("tests/fixtures/test_progress/foothold_with_neutral.lua")
+    sitac = load_sitac(lua_path)
+    # 1 rouge, 1 bleu, 1 neutre = (3-1)/3 = 66.67%
+    assert sitac.campaign_progress == pytest.approx(66.67, rel=0.01)
+
+
+def test_sitac_campaign_progress_excludes_hidden() -> None:
+    """Les zones cachées sont exclues du calcul"""
+    lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+    sitac = load_sitac(lua_path)
+    # Zones visibles: VisibleZone1 (rouge), VisibleZone2 (bleu)
+    # = (2-1)/2 = 50%
+    assert sitac.campaign_progress == 50.0
+
+
+def test_sitac_campaign_progress_no_zones() -> None:
+    """Sans zones, retourne 0"""
+    lua_path = Path("tests/fixtures/test_progress/foothold_empty.lua")
+    sitac = load_sitac(lua_path)
+    assert sitac.campaign_progress == 0.0


### PR DESCRIPTION
## Summary by Sourcery

Add campaign progress computation to the foothold SITAC model and surface it in the UI.

New Features:
- Expose a computed campaign_progress metric on the Sitac model based on visible zone ownership.
- Display overall campaign progress in the map navbar and within the objectives modal, including a progress bar and percentage.

Tests:
- Add unit tests and Lua fixtures to validate campaign_progress calculation across various zone configurations, including red, blue, neutral, hidden, and empty scenarios.