### PR TITLE
parse missions in new status file format

### DIFF
--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -74,3 +74,9 @@ async def foothold_players_modal(sitac: Annotated[Sitac, Depends(get_active_sita
 async def foothold_zones_modal(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> str:
     template = env.get_template("foothold/partials/zones.html")
     return template.render({"sitac": sitac, "progress": sitac.campaign_progress})
+
+
+@router.get("/map/{server}/missions", response_class=HTMLResponse)
+async def foothold_missions_modal(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> str:
+    template = env.get_template("foothold/partials/missions.html")
+    return template.render({"missions": sitac.missions})

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -66,9 +66,39 @@
             background: rgba(255, 255, 255, 0.1);
         }
 
+        .navbar-links a.disabled {
+            color: #5a6270;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
+        .navbar-links a.disabled:hover {
+            background: transparent;
+        }
+
         .navbar-brand i,
         .navbar-links a i {
             margin-right: 6px;
+        }
+
+        .navbar-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 18px;
+            height: 18px;
+            padding: 0 5px;
+            margin-left: 6px;
+            border-radius: 9px;
+            font-size: 11px;
+            font-weight: 600;
+            background: linear-gradient(145deg, #4263eb 0%, #3451c9 100%);
+            box-shadow: 0 2px 6px rgba(66, 99, 235, 0.3);
+        }
+
+        .navbar-links a.disabled .navbar-badge {
+            background: rgba(90, 98, 112, 0.5);
+            box-shadow: none;
         }
 
         /* Map container */
@@ -263,6 +293,7 @@
         <div class="navbar-links">
             <a href="#" onclick="openModal('players'); return false;"><i class="fa-solid fa-ranking-star"></i> Player Rankings</a>
             <a href="#" onclick="openModal('zones'); return false;"><i class="fa-solid fa-bullseye"></i> Objectives</a>
+            <a href="#" onclick="openModal('missions'); return false;" class="{% if sitac.missions|length == 0 %}disabled{% endif %}"><i class="fa-solid fa-crosshairs"></i> Missions<span class="navbar-badge">{{ sitac.missions|length }}</span></a>
             <span class="navbar-progress"><i class="fa-solid fa-flag"></i> {{ "%.0f"|format(progress) }}%</span>
             <a href="{{ request.url_for('foothold_servers') }}"><i class="fa-solid fa-list"></i> Servers</a>
         </div>
@@ -293,7 +324,8 @@
         // Modal functions
         const modalEndpoints = {
             players: '{{ request.url_for("foothold_players_modal", server=server) }}',
-            zones: '{{ request.url_for("foothold_zones_modal", server=server) }}'
+            zones: '{{ request.url_for("foothold_zones_modal", server=server) }}',
+            missions: '{{ request.url_for("foothold_missions_modal", server=server) }}'
         };
 
         async function openModal(type) {

--- a/templates/foothold/partials/missions.html
+++ b/templates/foothold/partials/missions.html
@@ -1,0 +1,126 @@
+<style>
+    .modal-table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    .modal-table th,
+    .modal-table td {
+        padding: 12px 14px;
+        text-align: left;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .modal-table th {
+        background: rgba(66, 99, 235, 0.15);
+        color: #e8eaed;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 12px;
+        letter-spacing: 0.5px;
+        border-bottom: 1px solid rgba(66, 99, 235, 0.3);
+    }
+
+    .modal-table tbody tr {
+        background: transparent;
+        transition: background 0.2s ease;
+    }
+
+    .modal-table tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.02);
+    }
+
+    .modal-table tbody tr:hover {
+        background: rgba(66, 99, 235, 0.1);
+    }
+
+    .modal-table td {
+        color: #c9cdd4;
+    }
+
+    .empty-state {
+        text-align: center;
+        color: #5a6270;
+        padding: 40px 20px;
+    }
+
+    .status-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 10px;
+        border-radius: 12px;
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    .status-badge.running {
+        background: linear-gradient(145deg, #22c55e 0%, #16a34a 100%);
+        color: white;
+        box-shadow: 0 2px 8px rgba(34, 197, 94, 0.4);
+    }
+
+    .status-badge.stopped {
+        background: rgba(107, 114, 128, 0.3);
+        color: #9ca3af;
+    }
+
+    .type-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 10px;
+        border-radius: 12px;
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    .type-badge.escort {
+        background: linear-gradient(145deg, #f59e0b 0%, #d97706 100%);
+        color: white;
+        box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+    }
+
+    .type-badge.attack {
+        background: linear-gradient(145deg, #ef4444 0%, #dc2626 100%);
+        color: white;
+        box-shadow: 0 2px 8px rgba(239, 68, 68, 0.4);
+    }
+</style>
+
+<h2>Active Missions</h2>
+
+{% if missions %}
+<table class="modal-table">
+    <thead>
+        <tr>
+            <th>Title</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for mission in missions %}
+        <tr>
+            <td>{{ mission.title }}</td>
+            <td>{{ mission.description }}</td>
+            <td>
+                {% if mission.is_escort_mission %}
+                <span class="type-badge escort"><i class="fa-solid fa-truck-fast"></i>&nbsp;Escort</span>
+                {% else %}
+                <span class="type-badge attack"><i class="fa-solid fa-crosshairs"></i>&nbsp;Attack</span>
+                {% endif %}
+            </td>
+            <td>
+                {% if mission.is_running %}
+                <span class="status-badge running"><i class="fa-solid fa-play"></i>&nbsp;Running</span>
+                {% else %}
+                <span class="status-badge stopped"><i class="fa-solid fa-pause"></i>&nbsp;Stopped</span>
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<div class="empty-state">No active missions</div>
+{% endif %}

--- a/tests/fixtures/test_missions/Missions/Saves/foothold.status
+++ b/tests/fixtures/test_missions/Missions/Saves/foothold.status
@@ -1,0 +1,1 @@
+tests/fixtures/test_missions/Missions/Saves/foothold_missions.lua

--- a/tests/fixtures/test_missions/Missions/Saves/foothold_missions.lua
+++ b/tests/fixtures/test_missions/Missions/Saves/foothold_missions.lua
@@ -1,0 +1,4 @@
+zonePersistance = {}
+zonePersistance['zones'] = { ['TestZone1']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['hidden']=false,['extraUpgrade']={ },['remainingUnits']={ },['wasBlue']=false,['lat_long']={ ['longitude']=9.64,['latitude']=50.54,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['triggers']={ ['missioncompleted']=0 } } }
+zonePersistance['missions'] = { [1]={ ['isEscortMission']=false,['description']='Destroy enemy forces at Hahn',['title']='Attack Hahn (3)',['isRunning']=true },[2]={ ['isEscortMission']=true,['description']='Escort friendly convoy to base',['title']='Convoy Escort',['isRunning']=false } }
+zonePersistance['playerStats'] = { }

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -82,3 +82,44 @@ def test_sitac_hidden_field_values(client: TestClient) -> None:
     assert zones["VisibleZone2"]["hidden"] is False
     assert zones["HiddenZone1"]["hidden"] is True
     assert zones["HiddenZone2"]["hidden"] is True
+
+
+# Missions tests
+
+
+def test_sitac_includes_missions(client: TestClient) -> None:
+    response = client.get("/api/foothold/test_missions/sitac")
+    assert response.status_code == 200
+
+    sitac = response.json()
+    assert "missions" in sitac
+    assert len(sitac["missions"]) == 2
+
+    # Check first mission (JSON uses aliases: isEscortMission, isRunning)
+    mission1 = sitac["missions"][0]
+    assert mission1["title"] == "Attack Hahn (3)"
+    assert mission1["description"] == "Destroy enemy forces at Hahn"
+    assert mission1["isEscortMission"] is False
+    assert mission1["isRunning"] is True
+
+    # Check second mission (escort)
+    mission2 = sitac["missions"][1]
+    assert mission2["title"] == "Convoy Escort"
+    assert mission2["isEscortMission"] is True
+    assert mission2["isRunning"] is False
+
+
+def test_sitac_without_missions_returns_empty_list(client: TestClient) -> None:
+    response = client.get("/api/foothold/test_hidden/sitac")
+    assert response.status_code == 200
+
+    sitac = response.json()
+    assert "missions" in sitac
+    assert sitac["missions"] == []
+
+
+def test_missions_modal_endpoint(client: TestClient) -> None:
+    response = client.get("/foothold/map/test_missions/missions")
+    assert response.status_code == 200
+    assert "Attack Hahn (3)" in response.text
+    assert "Convoy Escort" in response.text


### PR DESCRIPTION
## Summary by Sourcery

Add support for parsing and exposing foothold missions from the new status file format and display them in the web UI.

New Features:
- Parse missions from foothold status files into a new Mission model attached to Sitac.
- Expose missions via the existing sitac API and a new missions modal endpoint in the foothold map UI.
- Display missions in the map navbar with a badge showing mission count and a detailed missions modal table.

Tests:
- Add unit tests for Mission model validation and sitac loading with and without missions.
- Add integration tests for sitac missions in the API and missions modal endpoint.
- Add Lua fixture files representing foothold missions in the new status format.