### PR TITLE
add players positions

### DIFF
--- a/app/foothold.py
+++ b/app/foothold.py
@@ -65,6 +65,23 @@ class Connection(BaseModel):
     to_zone: str = Field(alias="to")
 
 
+class Player(BaseModel):
+    coalition: str
+    unit_type: str = Field(alias="unitType")
+    player_name: str = Field(alias="playerName")
+    latitude: float
+    longitude: float
+    altitude: float | None = None
+
+    @property
+    def side_color(self) -> str:
+        if self.coalition == "red":
+            return "red"
+        elif self.coalition == "blue":
+            return "blue"
+        return "gray"
+
+
 class PlayerStats(BaseModel):
     air: int = Field(alias="Air", default=0)
     SAM: int = Field(alias="SAM", default=0)
@@ -85,8 +102,9 @@ class Sitac(BaseModel):
     player_stats: dict[str, PlayerStats] = Field(alias="playerStats")
     missions: list[Mission] = Field(default_factory=list)
     connections: list[Connection] = Field(default_factory=list)
+    players: list[Player] = Field(default_factory=list)
 
-    @field_validator("missions", "connections", mode="before")
+    @field_validator("missions", "connections", "players", mode="before")
     @classmethod
     def convert_lua_table_to_list(cls, v: Any) -> list[Any]:
         """Convert Lua table (dict with numeric keys) to list."""

--- a/app/foothold_api_router.py
+++ b/app/foothold_api_router.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends
 from app.dependencies import get_active_sitac
 from app.foothold import Sitac, list_servers
-from app.schemas import MapConnection, MapData, MapZone, Server
+from app.schemas import MapConnection, MapData, MapPlayer, MapZone, Server
 
 router = APIRouter()
 
@@ -67,4 +67,19 @@ async def foothold_get_map_data(
 
     age_seconds = (datetime.now() - sitac.updated_at).total_seconds()
 
-    return MapData(updated_at=sitac.updated_at, age_seconds=age_seconds, zones=zones, connections=connections)
+    # Build players list
+    players = [
+        MapPlayer(
+            player_name=player.player_name,
+            lat=player.latitude,
+            lon=player.longitude,
+            coalition=player.coalition,
+            unit_type=player.unit_type,
+            color=player.side_color,
+        )
+        for player in sitac.players
+    ]
+
+    return MapData(
+        updated_at=sitac.updated_at, age_seconds=age_seconds, zones=zones, connections=connections, players=players
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -27,8 +27,18 @@ class MapConnection(BaseModel):
     color: str
 
 
+class MapPlayer(BaseModel):
+    player_name: str
+    lat: float
+    lon: float
+    coalition: str
+    unit_type: str
+    color: str
+
+
 class MapData(BaseModel):
     updated_at: datetime
     age_seconds: float
     zones: list[MapZone]
     connections: list[MapConnection]
+    players: list[MapPlayer] = []

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -282,6 +282,22 @@
         .zone-label .fa-truck {
             font-size: 14px;
         }
+
+        /* Player labels */
+        .player-label {
+            background: transparent;
+            border: none;
+            white-space: nowrap;
+            font-weight: bold;
+            font-size: 11px;
+            color: #333;
+            text-shadow: 1px 1px 2px white, -1px -1px 2px white, 1px -1px 2px white, -1px 1px 2px white;
+            text-align: center;
+        }
+
+        .player-label .fa-plane {
+            font-size: 16px;
+        }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 </head>
@@ -398,9 +414,11 @@
 
         const connectionsLayer = L.layerGroup().addTo(map);
         const zonesLayer = L.layerGroup().addTo(map);
+        const playersLayer = L.layerGroup().addTo(map);
         const labelsLayer = L.layerGroup().addTo(map);
         let zonesData = [];
         let connectionsData = [];
+        let playersData = [];
 
         // Coordinate conversion
         function toDMS(decimal, isLat) {
@@ -529,6 +547,40 @@
             });
         }
 
+        function createPlayerLabelContent(player, zoom) {
+            const planeIcon = `<i class="fa-solid fa-plane" style="color: ${player.color};"></i>`;
+
+            if (zoom < 10) {
+                // Low zoom: plane icon only
+                return planeIcon;
+            } else {
+                // Zoom 10+: plane icon + player name
+                return `${planeIcon}<br><span style="font-size: 10px;">${player.player_name}</span>`;
+            }
+        }
+
+        function updatePlayers() {
+            const zoom = map.getZoom();
+            playersLayer.clearLayers();
+
+            playersData.forEach(player => {
+                const content = createPlayerLabelContent(player, zoom);
+                const marker = L.marker([player.lat, player.lon], {
+                    icon: L.divIcon({
+                        className: 'player-label',
+                        html: content,
+                        iconSize: [120, 40],
+                        iconAnchor: [60, 20]
+                    })
+                });
+                marker.bindTooltip(`${player.player_name}<br>${player.unit_type}`, {
+                    direction: 'top',
+                    offset: [0, -10]
+                });
+                marker.addTo(playersLayer);
+            });
+        }
+
         // Freshness widget state
         const REFRESH_INTERVAL = 30;
         let nextRefresh = REFRESH_INTERVAL;
@@ -588,7 +640,9 @@
 
                     zonesData = data.zones;
                     connectionsData = data.connections || [];
+                    playersData = data.players || [];
                     updateConnections();
+                    updatePlayers();
                     updateLabels();
                 })
                 .catch(error => {
@@ -613,8 +667,11 @@
         loadData(); // initial load
         setInterval(loadData, REFRESH_INTERVAL * 1000); // refresh every REFRESH_INTERVAL seconds
 
-        // Update labels on zoom change
-        map.on('zoomend', updateLabels);
+        // Update labels and players on zoom change
+        map.on('zoomend', () => {
+            updateLabels();
+            updatePlayers();
+        });
     </script>
 </body>
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for exposing player position data from the SITAC through the API and rendering it on the foothold map.

New Features:
- Introduce a Player model in the SITAC data with coalition, position, and unit metadata.
- Expose mapped player data via the foothold map API response.
- Render player positions and labels on the foothold map with zoom-aware icons and tooltips.

Tests:
- Add unit tests for Player model validation, coalition color mapping, and SITAC loading with and without player data.