### PR TITLE
Feature/54 add ejectedpilots informations

### DIFF
--- a/app/foothold.py
+++ b/app/foothold.py
@@ -82,6 +82,14 @@ class Player(BaseModel):
         return "gray"
 
 
+class EjectedPilot(BaseModel):
+    player_name: str = Field(alias="playerName")
+    latitude: float
+    longitude: float
+    altitude: float = 0
+    lost_credits: int = Field(alias="lostCredits", default=0)
+
+
 class PlayerStats(BaseModel):
     air: int = Field(alias="Air", default=0)
     SAM: int = Field(alias="SAM", default=0)
@@ -103,8 +111,9 @@ class Sitac(BaseModel):
     missions: list[Mission] = Field(default_factory=list)
     connections: list[Connection] = Field(default_factory=list)
     players: list[Player] = Field(default_factory=list)
+    ejected_pilots: list[EjectedPilot] = Field(alias="ejectedPilots", default_factory=list)
 
-    @field_validator("missions", "connections", "players", mode="before")
+    @field_validator("missions", "connections", "players", "ejected_pilots", mode="before")
     @classmethod
     def convert_lua_table_to_list(cls, v: Any) -> list[Any]:
         """Convert Lua table (dict with numeric keys) to list."""

--- a/app/foothold_api_router.py
+++ b/app/foothold_api_router.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends
 from app.dependencies import get_active_sitac
 from app.foothold import Sitac, list_servers
-from app.schemas import MapConnection, MapData, MapPlayer, MapZone, Server
+from app.schemas import MapConnection, MapData, MapEjectedPilot, MapPlayer, MapZone, Server
 
 router = APIRouter()
 
@@ -80,12 +80,27 @@ async def foothold_get_map_data(
         for player in sitac.players
     ]
 
+    # Build ejected pilots list (exclude "Unknown" pilots)
+    ejected_pilots = [
+        MapEjectedPilot(
+            player_name=pilot.player_name,
+            lat=pilot.latitude,
+            lon=pilot.longitude,
+            altitude=pilot.altitude,
+            lost_credits=pilot.lost_credits,
+        )
+        for pilot in sitac.ejected_pilots
+        if pilot.player_name != "Unknown"
+    ]
+
     return MapData(
         updated_at=sitac.updated_at,
         age_seconds=age_seconds,
         zones=zones,
         connections=connections,
         players=players,
+        ejected_pilots=ejected_pilots,
         progress=sitac.campaign_progress,
         missions_count=len(sitac.missions),
+        ejected_pilots_count=len(ejected_pilots),
     )

--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -80,3 +80,11 @@ async def foothold_zones_modal(sitac: Annotated[Sitac, Depends(get_active_sitac)
 async def foothold_missions_modal(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> str:
     template = env.get_template("foothold/partials/missions.html")
     return template.render({"missions": sitac.missions})
+
+
+@router.get("/map/{server}/ejected", response_class=HTMLResponse)
+async def foothold_ejected_modal(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> str:
+    template = env.get_template("foothold/partials/ejected.html")
+    # Filter out "Unknown" pilots
+    ejected_pilots = [p for p in sitac.ejected_pilots if p.player_name != "Unknown"]
+    return template.render({"ejected_pilots": ejected_pilots})

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -36,11 +36,21 @@ class MapPlayer(BaseModel):
     color: str
 
 
+class MapEjectedPilot(BaseModel):
+    player_name: str
+    lat: float
+    lon: float
+    altitude: float
+    lost_credits: int
+
+
 class MapData(BaseModel):
     updated_at: datetime
     age_seconds: float
     zones: list[MapZone]
     connections: list[MapConnection]
     players: list[MapPlayer] = []
+    ejected_pilots: list[MapEjectedPilot] = []
     progress: float
     missions_count: int
+    ejected_pilots_count: int = 0

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Server(BaseModel):
@@ -49,8 +49,8 @@ class MapData(BaseModel):
     age_seconds: float
     zones: list[MapZone]
     connections: list[MapConnection]
-    players: list[MapPlayer] = []
-    ejected_pilots: list[MapEjectedPilot] = []
+    players: list[MapPlayer] = Field(default_factory=list)
+    ejected_pilots: list[MapEjectedPilot] = Field(default_factory=list)
     progress: float
     missions_count: int
     ejected_pilots_count: int = 0

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -46,6 +46,33 @@
             font-weight: 600;
             background: linear-gradient(145deg, #4263eb 0%, #3451c9 100%);
             box-shadow: 0 2px 8px rgba(66, 99, 235, 0.4);
+            position: relative;
+            cursor: default;
+        }
+
+        .navbar-progress .navbar-tooltip {
+            visibility: hidden;
+            opacity: 0;
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            margin-top: 8px;
+            padding: 6px 10px;
+            background: #1a1f2a;
+            color: #e8eaed;
+            font-size: 12px;
+            font-weight: 400;
+            border-radius: 6px;
+            white-space: nowrap;
+            z-index: 1002;
+            transition: opacity 0.2s ease, visibility 0.2s ease;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        }
+
+        .navbar-progress:hover .navbar-tooltip {
+            visibility: visible;
+            opacity: 1;
         }
 
         .navbar-links {
@@ -327,8 +354,8 @@
             <a href="#" onclick="openModal('players'); return false;"><i class="fa-solid fa-ranking-star"></i> Player Rankings</a>
             <a href="#" onclick="openModal('zones'); return false;"><i class="fa-solid fa-bullseye"></i> Objectives</a>
             <a href="#" onclick="openModal('missions'); return false;" id="missions-link" class="{% if sitac.missions|length == 0 %}disabled{% endif %}"><i class="fa-solid fa-crosshairs"></i> Missions<span class="navbar-badge" id="missions-badge">{{ sitac.missions|length }}</span></a>
-            <span class="navbar-progress" id="ejected-pilots-info" style="{% if sitac.ejected_pilots|length == 0 %}display: none;{% endif %} background: linear-gradient(145deg, #e67e22 0%, #d35400 100%); box-shadow: 0 2px 8px rgba(230, 126, 34, 0.4);"><i class="fa-solid fa-parachute-box"></i> <span id="ejected-pilots-count">{{ sitac.ejected_pilots|length }}</span></span>
-            <span class="navbar-progress"><i class="fa-solid fa-flag"></i> <span id="progress-value">{{ "%.0f"|format(progress) }}</span>%</span>
+            <span class="navbar-progress" id="ejected-pilots-info" onclick="openModal('ejected')" style="cursor: pointer; {% if sitac.ejected_pilots|length == 0 %}display: none;{% endif %} background: linear-gradient(145deg, #e67e22 0%, #d35400 100%); box-shadow: 0 2px 8px rgba(230, 126, 34, 0.4);"><i class="fa-solid fa-parachute-box"></i> <span id="ejected-pilots-count">{{ sitac.ejected_pilots|length }}</span><span class="navbar-tooltip">Ejected pilots awaiting rescue (click for details)</span></span>
+            <span class="navbar-progress"><i class="fa-solid fa-flag"></i> <span id="progress-value">{{ "%.0f"|format(progress) }}</span>%<span class="navbar-tooltip">Campaign progress</span></span>
             <a href="{{ request.url_for('foothold_servers') }}"><i class="fa-solid fa-list"></i> Servers</a>
         </div>
     </nav>
@@ -359,7 +386,8 @@
         const modalEndpoints = {
             players: '{{ request.url_for("foothold_players_modal", server=server) }}',
             zones: '{{ request.url_for("foothold_zones_modal", server=server) }}',
-            missions: '{{ request.url_for("foothold_missions_modal", server=server) }}'
+            missions: '{{ request.url_for("foothold_missions_modal", server=server) }}',
+            ejected: '{{ request.url_for("foothold_ejected_modal", server=server) }}'
         };
 
         async function openModal(type) {

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -298,6 +298,23 @@
         .player-label .fa-plane {
             font-size: 16px;
         }
+
+        /* Ejected pilots labels */
+        .ejection-label {
+            background: transparent;
+            border: none;
+            white-space: nowrap;
+            font-weight: bold;
+            font-size: 10px;
+            color: #333;
+            text-shadow: 1px 1px 2px white, -1px -1px 2px white, 1px -1px 2px white, -1px 1px 2px white;
+            text-align: center;
+        }
+
+        .ejection-label .fa-parachute-box {
+            font-size: 16px;
+            color: orange;
+        }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 </head>
@@ -310,6 +327,7 @@
             <a href="#" onclick="openModal('players'); return false;"><i class="fa-solid fa-ranking-star"></i> Player Rankings</a>
             <a href="#" onclick="openModal('zones'); return false;"><i class="fa-solid fa-bullseye"></i> Objectives</a>
             <a href="#" onclick="openModal('missions'); return false;" id="missions-link" class="{% if sitac.missions|length == 0 %}disabled{% endif %}"><i class="fa-solid fa-crosshairs"></i> Missions<span class="navbar-badge" id="missions-badge">{{ sitac.missions|length }}</span></a>
+            <span class="navbar-progress" id="ejected-pilots-info" style="{% if sitac.ejected_pilots|length == 0 %}display: none;{% endif %} background: linear-gradient(145deg, #e67e22 0%, #d35400 100%); box-shadow: 0 2px 8px rgba(230, 126, 34, 0.4);"><i class="fa-solid fa-parachute-box"></i> <span id="ejected-pilots-count">{{ sitac.ejected_pilots|length }}</span></span>
             <span class="navbar-progress"><i class="fa-solid fa-flag"></i> <span id="progress-value">{{ "%.0f"|format(progress) }}</span>%</span>
             <a href="{{ request.url_for('foothold_servers') }}"><i class="fa-solid fa-list"></i> Servers</a>
         </div>
@@ -416,9 +434,11 @@
         const zonesLayer = L.layerGroup().addTo(map);
         const playersLayer = L.layerGroup().addTo(map);
         const labelsLayer = L.layerGroup().addTo(map);
+        const ejectionsLayer = L.layerGroup().addTo(map);
         let zonesData = [];
         let connectionsData = [];
         let playersData = [];
+        let ejectionsData = [];
 
         // Coordinate conversion
         function toDMS(decimal, isLat) {
@@ -581,13 +601,42 @@
             });
         }
 
+        // Ejected pilots
+        function updateEjections() {
+            const zoom = map.getZoom();
+            ejectionsLayer.clearLayers();
+
+            ejectionsData.forEach(pilot => {
+                const icon = `<i class="fa-solid fa-parachute-box"></i>`;
+                const content = zoom >= 10
+                    ? `${icon}<br><span style="font-size: 9px;">${pilot.player_name}</span>`
+                    : icon;
+
+                const marker = L.marker([pilot.lat, pilot.lon], {
+                    icon: L.divIcon({
+                        className: 'ejection-label',
+                        html: content,
+                        iconSize: [100, 40],
+                        iconAnchor: [50, 20]
+                    })
+                });
+
+                marker.bindTooltip(`${pilot.player_name}<br>Alt: ${Math.round(pilot.altitude)}m`, {
+                    direction: 'top',
+                    offset: [0, -10]
+                });
+
+                marker.addTo(ejectionsLayer);
+            });
+        }
+
         // Freshness widget state
         const REFRESH_INTERVAL = 30;
         let nextRefresh = REFRESH_INTERVAL;
         let dataAgeSeconds = 0;
         let isConnected = true;
 
-        function updateNavbar(progress, missionsCount) {
+        function updateNavbar(progress, missionsCount, ejectedPilotsCount) {
             // Update progress percentage
             const progressElement = document.getElementById('progress-value');
             if (progressElement) {
@@ -606,6 +655,16 @@
                 } else {
                     missionsLink.classList.remove('disabled');
                 }
+            }
+
+            // Update ejected pilots count
+            const ejectedCount = document.getElementById('ejected-pilots-count');
+            const ejectedInfo = document.getElementById('ejected-pilots-info');
+            if (ejectedCount) {
+                ejectedCount.textContent = ejectedPilotsCount;
+            }
+            if (ejectedInfo) {
+                ejectedInfo.style.display = ejectedPilotsCount > 0 ? 'inline-flex' : 'none';
             }
         }
 
@@ -647,7 +706,7 @@
                     dataAgeSeconds = data.age_seconds;
                     nextRefresh = REFRESH_INTERVAL;
                     updateFreshnessWidget();
-                    updateNavbar(data.progress, data.missions_count);
+                    updateNavbar(data.progress, data.missions_count, data.ejected_pilots_count);
 
                     zonesLayer.clearLayers();
                     data.zones.forEach(p => {
@@ -664,8 +723,10 @@
                     zonesData = data.zones;
                     connectionsData = data.connections || [];
                     playersData = data.players || [];
+                    ejectionsData = data.ejected_pilots || [];
                     updateConnections();
                     updatePlayers();
+                    updateEjections();
                     updateLabels();
                 })
                 .catch(error => {
@@ -690,10 +751,11 @@
         loadData(); // initial load
         setInterval(loadData, REFRESH_INTERVAL * 1000); // refresh every REFRESH_INTERVAL seconds
 
-        // Update labels and players on zoom change
+        // Update labels, players and ejections on zoom change
         map.on('zoomend', () => {
             updateLabels();
             updatePlayers();
+            updateEjections();
         });
     </script>
 </body>

--- a/templates/foothold/partials/ejected.html
+++ b/templates/foothold/partials/ejected.html
@@ -1,0 +1,97 @@
+<style>
+    .modal-table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    .modal-table th,
+    .modal-table td {
+        padding: 12px 14px;
+        text-align: left;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .modal-table td.n {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .modal-table th {
+        background: rgba(230, 126, 34, 0.15);
+        color: #e8eaed;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 12px;
+        letter-spacing: 0.5px;
+        border-bottom: 1px solid rgba(230, 126, 34, 0.3);
+    }
+
+    .modal-table tbody tr {
+        background: transparent;
+        transition: background 0.2s ease;
+    }
+
+    .modal-table tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.02);
+    }
+
+    .modal-table tbody tr:hover {
+        background: rgba(230, 126, 34, 0.1);
+    }
+
+    .modal-table td {
+        color: #c9cdd4;
+    }
+
+    .ejected-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 16px;
+    }
+
+    .ejected-header i {
+        color: #e67e22;
+        font-size: 24px;
+    }
+
+    .ejected-header h2 {
+        margin: 0;
+    }
+
+    .coords {
+        font-family: monospace;
+        font-size: 12px;
+    }
+</style>
+
+<div class="ejected-header">
+    <i class="fa-solid fa-parachute-box"></i>
+    <h2>Ejected Pilots</h2>
+</div>
+<table class="modal-table">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Pilot</th>
+            <th>Latitude</th>
+            <th>Longitude</th>
+            <th>Altitude</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for pilot in ejected_pilots %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ pilot.player_name }}</td>
+            <td class="coords">{{ "%.6f"|format(pilot.latitude) }}</td>
+            <td class="coords">{{ "%.6f"|format(pilot.longitude) }}</td>
+            <td class="n">{{ pilot.altitude | int }}m</td>
+        </tr>
+        {% else %}
+        <tr>
+            <td colspan="5" style="text-align: center; color: #5a6270;">No ejected pilots</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/tests/fixtures/test_ejected/Missions/Saves/foothold_ejected.lua
+++ b/tests/fixtures/test_ejected/Missions/Saves/foothold_ejected.lua
@@ -1,0 +1,33 @@
+zonePersistance = {}
+zonePersistance['zones'] = {
+    ['TestZone1']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=10.0,['latitude']=52.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['TestZone2']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=11.0,['latitude']=53.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=2,['wasBlue']=true,['triggers']={ ['missioncompleted']=1 } }
+}
+zonePersistance['zonesDetails'] = {
+    ['TestZone1']={ ['hidden']=false },
+    ['TestZone2']={ ['hidden']=false }
+}
+zonePersistance['playerStats'] = { }
+zonePersistance['ejectedPilots'] = {
+    [1]={
+        ['altitude']=49.431312561035,
+        ['longitude']=11.059029269508,
+        ['latitude']=52.850300007598,
+        ['playerName']='Unknown',
+        ['lostCredits']=0,
+    },
+    [2]={
+        ['altitude']=51.940250396729,
+        ['longitude']=10.536946955576,
+        ['latitude']=52.903069323266,
+        ['playerName']='Unknown',
+        ['lostCredits']=0,
+    },
+    [3]={
+        ['altitude']=53.148307800293,
+        ['longitude']=10.536379454041,
+        ['latitude']=52.90260133955,
+        ['playerName']='Unknown',
+        ['lostCredits']=0,
+    },
+}


### PR DESCRIPTION
## Summary by Sourcery

Add support for tracking and displaying ejected pilots on the foothold map and in a dedicated modal, including backend data models, API wiring, and UI integration.

New Features:
- Introduce an EjectedPilot domain model and wire ejected pilots into the Sitac state loaded from Lua saves.
- Expose ejected pilot information via map API schemas and responses, including a separate count field.
- Add a new ejected pilots navbar indicator and map layer with parachute markers and tooltips, plus a modal listing pilot details.

Tests:
- Add unit tests for the EjectedPilot model, Sitac loading with and without ejected pilots, and a fixture Lua file containing ejectedPilots data.