### PR TITLE
fix ejected pilots with decimal lost_credits, display Unknown pilots

### DIFF
--- a/app/foothold.py
+++ b/app/foothold.py
@@ -87,7 +87,7 @@ class EjectedPilot(BaseModel):
     latitude: float
     longitude: float
     altitude: float = 0
-    lost_credits: int = Field(alias="lostCredits", default=0)
+    lost_credits: float = Field(alias="lostCredits", default=0)
 
 
 class PlayerStats(BaseModel):

--- a/app/foothold_api_router.py
+++ b/app/foothold_api_router.py
@@ -90,7 +90,7 @@ async def foothold_get_map_data(
             lost_credits=pilot.lost_credits,
         )
         for pilot in sitac.ejected_pilots
-        if pilot.player_name != "Unknown"
+        # if pilot.player_name != "Unknown" # don't hide Unknown pilots, real pilots have this name
     ]
 
     return MapData(

--- a/app/foothold_router.py
+++ b/app/foothold_router.py
@@ -86,5 +86,6 @@ async def foothold_missions_modal(sitac: Annotated[Sitac, Depends(get_active_sit
 async def foothold_ejected_modal(sitac: Annotated[Sitac, Depends(get_active_sitac)]) -> str:
     template = env.get_template("foothold/partials/ejected.html")
     # Filter out "Unknown" pilots
-    ejected_pilots = [p for p in sitac.ejected_pilots if p.player_name != "Unknown"]
-    return template.render({"ejected_pilots": ejected_pilots})
+    # ejected_pilots = [p for p in sitac.ejected_pilots if p.player_name != "Unknown"]
+    # return template.render({"ejected_pilots": ejected_pilots})
+    return template.render({"ejected_pilots": sitac.ejected_pilots})

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -41,7 +41,7 @@ class MapEjectedPilot(BaseModel):
     lat: float
     lon: float
     altitude: float
-    lost_credits: int
+    lost_credits: float
 
 
 class MapData(BaseModel):

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -442,6 +442,10 @@
             font-size: 16px;
             color: orange;
         }
+
+        .ejection-label.green .fa-parachute-box {
+            color: #28a745;
+        }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 </head>
@@ -515,6 +519,134 @@
 
         function closeModal() {
             document.getElementById('modal-overlay').classList.remove('visible', 'zone-modal');
+        }
+
+        // Convert decimal degrees to DMS (degrees, minutes, seconds)
+        function decimalToDMS(decimal, isLat) {
+            const direction = isLat ? (decimal >= 0 ? 'N' : 'S') : (decimal >= 0 ? 'E' : 'W');
+            const absolute = Math.abs(decimal);
+            const degrees = Math.floor(absolute);
+            const minutesDecimal = (absolute - degrees) * 60;
+            const minutes = Math.floor(minutesDecimal);
+            const seconds = ((minutesDecimal - minutes) * 60).toFixed(2);
+            return `${degrees}° ${minutes}' ${seconds}" ${direction}`;
+        }
+
+        // Convert decimal degrees to decimal minutes (DDM)
+        function decimalToDDM(decimal, isLat) {
+            const direction = isLat ? (decimal >= 0 ? 'N' : 'S') : (decimal >= 0 ? 'E' : 'W');
+            const absolute = Math.abs(decimal);
+            const degrees = Math.floor(absolute);
+            const minutes = ((absolute - degrees) * 60).toFixed(4);
+            return `${degrees}° ${minutes}' ${direction}`;
+        }
+
+        // Open modal for ejected pilot details
+        function openPilotModal(pilot) {
+            const overlay = document.getElementById('modal-overlay');
+            const body = document.getElementById('modal-body');
+
+            const color = pilot.lost_credits > 0 ? '#28a745' : '#e67e22';
+
+            body.innerHTML = `
+                <style>
+                    .pilot-modal-header {
+                        display: flex;
+                        align-items: center;
+                        gap: 10px;
+                        margin-bottom: 16px;
+                    }
+                    .pilot-modal-header i {
+                        color: ${color};
+                        font-size: 24px;
+                    }
+                    .pilot-modal-header h2 {
+                        margin: 0;
+                    }
+                    .pilot-coords {
+                        background: rgba(255, 255, 255, 0.05);
+                        border-radius: 8px;
+                        padding: 16px;
+                        margin-bottom: 12px;
+                    }
+                    .pilot-coords h3 {
+                        margin: 0 0 12px 0;
+                        font-size: 14px;
+                        color: #888;
+                        text-transform: uppercase;
+                    }
+                    .pilot-coords-row {
+                        display: flex;
+                        justify-content: space-between;
+                        padding: 8px 0;
+                        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+                        font-family: monospace;
+                    }
+                    .pilot-coords-row:last-child {
+                        border-bottom: none;
+                    }
+                    .pilot-coords-label {
+                        color: #888;
+                    }
+                    .pilot-coords-value {
+                        color: #e8eaed;
+                    }
+                    .pilot-info-row {
+                        display: flex;
+                        justify-content: space-between;
+                        padding: 8px 0;
+                    }
+                </style>
+                <div class="pilot-modal-header">
+                    <i class="fa-solid fa-parachute-box"></i>
+                    <h2>${pilot.player_name}</h2>
+                </div>
+                <div class="pilot-coords">
+                    <h3>Decimal Degrees</h3>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Latitude</span>
+                        <span class="pilot-coords-value">${pilot.lat.toFixed(6)}°</span>
+                    </div>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Longitude</span>
+                        <span class="pilot-coords-value">${pilot.lon.toFixed(6)}°</span>
+                    </div>
+                </div>
+                <div class="pilot-coords">
+                    <h3>Degrees Decimal Minutes (DDM)</h3>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Latitude</span>
+                        <span class="pilot-coords-value">${decimalToDDM(pilot.lat, true)}</span>
+                    </div>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Longitude</span>
+                        <span class="pilot-coords-value">${decimalToDDM(pilot.lon, false)}</span>
+                    </div>
+                </div>
+                <div class="pilot-coords">
+                    <h3>Degrees Minutes Seconds (DMS)</h3>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Latitude</span>
+                        <span class="pilot-coords-value">${decimalToDMS(pilot.lat, true)}</span>
+                    </div>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Longitude</span>
+                        <span class="pilot-coords-value">${decimalToDMS(pilot.lon, false)}</span>
+                    </div>
+                </div>
+                <div class="pilot-coords">
+                    <h3>Other Info</h3>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Altitude</span>
+                        <span class="pilot-coords-value">${Math.round(pilot.altitude)}m</span>
+                    </div>
+                    <div class="pilot-coords-row">
+                        <span class="pilot-coords-label">Lost Credits</span>
+                        <span class="pilot-coords-value">${Math.round(pilot.lost_credits)}</span>
+                    </div>
+                </div>
+            `;
+            overlay.classList.add('visible');
         }
 
         function closeModalOnOverlay(event) {
@@ -741,7 +873,7 @@
 
                 const marker = L.marker([pilot.lat, pilot.lon], {
                     icon: L.divIcon({
-                        className: 'ejection-label',
+                        className: pilot.lost_credits > 0 ? 'ejection-label green' : 'ejection-label',
                         html: content,
                         iconSize: [100, 40],
                         iconAnchor: [50, 20]
@@ -752,6 +884,8 @@
                     direction: 'top',
                     offset: [0, -10]
                 });
+
+                marker.on('click', () => openPilotModal(pilot));
 
                 marker.addTo(ejectionsLayer);
             });

--- a/templates/foothold/partials/ejected.html
+++ b/templates/foothold/partials/ejected.html
@@ -77,20 +77,22 @@
             <th>Latitude</th>
             <th>Longitude</th>
             <th>Altitude</th>
+            <th>Credits</th>
         </tr>
     </thead>
     <tbody>
         {% for pilot in ejected_pilots %}
         <tr>
             <td class="n">{{ loop.index }}</td>
-            <td>{{ pilot.player_name }}</td>
+            <td><i class="fa-solid fa-parachute-box" style="color: {% if pilot.lost_credits > 0 %}#28a745{% else %}#e67e22{% endif %};"></i> {{ pilot.player_name }}</td>
             <td class="coords">{{ "%.6f"|format(pilot.latitude) }}</td>
             <td class="coords">{{ "%.6f"|format(pilot.longitude) }}</td>
             <td class="n">{{ pilot.altitude | int }}m</td>
+            <td class="n">{{ pilot.lost_credits | int }}</td>
         </tr>
         {% else %}
         <tr>
-            <td colspan="5" style="text-align: center; color: #5a6270;">No ejected pilots</td>
+            <td colspan="6" style="text-align: center; color: #5a6270;">No ejected pilots</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/tests/fixtures/test_ejected/Missions/Saves/foothold_ejected.lua
+++ b/tests/fixtures/test_ejected/Missions/Saves/foothold_ejected.lua
@@ -14,7 +14,7 @@ zonePersistance['ejectedPilots'] = {
         ['longitude']=11.059029269508,
         ['latitude']=52.850300007598,
         ['playerName']='Unknown',
-        ['lostCredits']=0,
+        ['lostCredits']=337.5,
     },
     [2]={
         ['altitude']=51.940250396729,

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -333,6 +333,20 @@ def test_ejected_pilot_model_with_credits() -> None:
     assert pilot.lost_credits == 500
 
 
+def test_ejected_pilot_model_with_float_credits() -> None:
+    """Test EjectedPilot model with float lost credits (DCS can send decimals)"""
+    pilot_data = {
+        "playerName": "Viper 1-1",
+        "latitude": 50.0,
+        "longitude": 10.0,
+        "altitude": 100.0,
+        "lostCredits": 337.5,
+    }
+    pilot = EjectedPilot.model_validate(pilot_data)
+    assert pilot.player_name == "Viper 1-1"
+    assert pilot.lost_credits == 337.5
+
+
 def test_ejected_pilot_model_defaults() -> None:
     """Test EjectedPilot model with default values"""
     pilot_data = {


### PR DESCRIPTION
## Summary by Sourcery

Allow ejected pilots with decimal lost_credits values to be represented and surfaced instead of filtered out as Unknown.

Bug Fixes:
- Preserve ejected pilots whose player_name is 'Unknown' instead of filtering them out from the UI and map API responses.
- Support non-integer (decimal) lost_credits values for ejected pilots throughout the data model and related fixtures.

Tests:
- Add unit coverage to ensure EjectedPilot correctly handles float lostCredits values from DCS.