### PR TITLE
fix zone clic

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -169,6 +169,9 @@ function updateLabels() {
                     iconAnchor: [50, 20]
                 })
             });
+            marker.on('click', function() {
+                openZoneModal(zone);
+            });
             marker.addTo(labelsLayer);
         }
     });
@@ -344,11 +347,6 @@ function loadData() {
                     fillOpacity: 0.3,
                     radius: Math.min(20000, Math.max(2000, 2000 * p.level)),
                 }).addTo(zonesLayer);
-
-                circle.bindTooltip(p.name + '<br>Units: ' + p.units, {
-                    direction: 'top',
-                    offset: [0, -10]
-                });
 
                 circle.on('click', function() {
                     openZoneModal(p);


### PR DESCRIPTION
## Summary by Sourcery

Enable opening the zone modal by clicking on label markers and remove redundant circle tooltips now that zone details are shown in the modal.

New Features:
- Allow zone label markers to open the zone detail modal when clicked.

Enhancements:
- Rely solely on the zone modal for zone details by removing the circle tooltip display.