### PR TITLE
don't display hidden objectives in objectives list

### DIFF
--- a/templates/foothold/partials/zones.html
+++ b/templates/foothold/partials/zones.html
@@ -2,15 +2,13 @@
 {% set neutral_zones = [] %}
 {% set red_zones = [] %}
 
-{% for name, zone in sitac.zones.items() | sort %}
-    {% if not zone.hidden %}
-        {% if zone.side == 2 %}
-            {% set _ = blue_zones.append((name, zone)) %}
-        {% elif zone.side == 1 %}
-            {% set _ = red_zones.append((name, zone)) %}
-        {% else %}
-            {% set _ = neutral_zones.append((name, zone)) %}
-        {% endif %}
+{% for name, zone in sitac.zones.items() | sort if not zone.hidden %}
+    {% if zone.side == 2 %}
+        {% set _ = blue_zones.append((name, zone)) %}
+    {% elif zone.side == 1 %}
+        {% set _ = red_zones.append((name, zone)) %}
+    {% else %}
+        {% set _ = neutral_zones.append((name, zone)) %}
     {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Exclude zones marked as hidden from being added to blue, red, or neutral zone collections in the objectives view.