### PR TITLE
add github repository link, fix responsive server name

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ async def home(request: Request) -> str:
 
 
 @app.get("/favicon.ico", include_in_schema=False)
-async def favicon():
+async def favicon() -> RedirectResponse:
     return RedirectResponse(url="/static/favicon.ico")
 
 

--- a/static/css/navbar.css
+++ b/static/css/navbar.css
@@ -95,6 +95,26 @@
     margin-right: 8px;
 }
 
+.navbar-dropdown-header {
+    display: block;
+    padding: 10px 14px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.navbar-dropdown-header i {
+    margin-right: 8px;
+}
+
+.navbar-dropdown-separator {
+    height: 1px;
+    background: rgba(255, 255, 255, 0.1);
+    margin: 4px 0;
+}
+
 .navbar-brand i,
 .navbar-links a i {
     margin-right: 6px;
@@ -232,7 +252,8 @@
 
 /* Responsive navbar */
 @media (max-width: 1000px) {
-    .navbar-link-label {
+    .navbar-link-label,
+    .navbar-brand-label {
         display: none;
     }
 

--- a/templates/foothold/map.html
+++ b/templates/foothold/map.html
@@ -17,10 +17,13 @@
 <nav class="navbar">
     <div class="navbar-brand-dropdown">
         <span class="navbar-brand" onclick="toggleServerDropdown()">
-            <i class="fa-solid fa-server"></i> {{ server }} <i class="fa-solid fa-chevron-down navbar-brand-chevron"></i>
+            <i class="fa-solid fa-server"></i><span class="navbar-brand-label"> {{ server }}</span> <i class="fa-solid fa-chevron-down navbar-brand-chevron"></i>
         </span>
         <div class="navbar-dropdown" id="server-dropdown">
+            <span class="navbar-dropdown-header"><i class="fa-solid fa-server"></i> {{ server }}</span>
             <a href="{{ request.url_for('foothold_servers') }}"><i class="fa-solid fa-list"></i> Back to server list</a>
+            <div class="navbar-dropdown-separator"></div>
+            <a href="https://github.com/VEAF/foothold-sitac" target="_blank" rel="noopener"><i class="fa-brands fa-github"></i> GitHub</a>
         </div>
     </div>
     <div class="navbar-links">


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub repository link to the server dropdown and adjust navbar responsiveness and favicon handling.

New Features:
- Add a GitHub repository link in the server dropdown menu on the foothold map page.

Bug Fixes:
- Preserve the server name visibility in the navbar on smaller screens while keeping link labels hidden.
- Specify the redirect response type for the favicon endpoint.

Enhancements:
- Add styled header and separator elements to the server dropdown menu for clearer structure.