### PR TITLE
disabled (active=false) zones are now in darkgray, not in progress

### DIFF
--- a/app/foothold.py
+++ b/app/foothold.py
@@ -52,7 +52,6 @@ class Zone(BaseModel):
             return "blue"
         return "neutral"
 
-
     @property
     def total_units(self) -> int:
         return sum([len(group_units) for group_units in self.remaining_units.values()])
@@ -138,15 +137,11 @@ class Sitac(BaseModel):
         Hidden zones (hidden=True) and inactive zones (active=False) are
         excluded.
         """
-        visible_zones = [
-            z for z in self.zones.values()
-            if not z.hidden and z.active
-        ]
+        visible_zones = [z for z in self.zones.values() if not z.hidden and z.active]
         if not visible_zones:
             return 0.0
         red_zones = sum(1 for z in visible_zones if z.side == 1)
         return (len(visible_zones) - red_zones) / len(visible_zones) * 100
-
 
 
 def lua_to_dict(lua_table: Any) -> dict[Any, Any] | None:


### PR DESCRIPTION
## Summary by Sourcery

Adjust zone presentation and campaign progress calculations to treat inactive zones as disabled rather than in-progress.

New Features:
- Display inactive zones with a dark gray color and a "disabled" label instead of a side-based status.

Enhancements:
- Exclude inactive zones from campaign progress calculations alongside hidden zones.