### PR TITLE
fix campaign progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Foothold Sitac is a web application that displays tactical maps (sitac) for DCS 
 poetry install --only main
 
 # Run the web server
-python run.py
+poetry run python run.py
 
 # Run tests
 poetry run pytest

--- a/src/foothold_sitac/foothold.py
+++ b/src/foothold_sitac/foothold.py
@@ -132,16 +132,20 @@ class Sitac(BaseModel):
         """Return the campaign progress percentage (0-100).
 
         Progress is calculated as:
-        (visible_zones - red_zones) / visible_zones * 100
+        blue_zones / (blue_zones + red_zones) * 100
 
         Hidden zones (hidden=True) and inactive zones (active=False) are
-        excluded.
+        excluded. Neutral zones (side=0) are ignored.
         """
         visible_zones = [z for z in self.zones.values() if not z.hidden and z.active]
         if not visible_zones:
             return 0.0
+        blue_zones = sum(1 for z in visible_zones if z.side == 2)
         red_zones = sum(1 for z in visible_zones if z.side == 1)
-        return (len(visible_zones) - red_zones) / len(visible_zones) * 100
+        total_contested = blue_zones + red_zones
+        if total_contested == 0:
+            return 0.0
+        return blue_zones / total_contested * 100
 
 
 def lua_to_dict(lua_table: Any) -> dict[Any, Any] | None:

--- a/tests/fixtures/test_progress/foothold_with_active_neutral.lua
+++ b/tests/fixtures/test_progress/foothold_with_active_neutral.lua
@@ -1,0 +1,8 @@
+zonePersistance = {}
+zonePersistance['zones'] = {
+    ['RedZone']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=36.0,['latitude']=33.0,['altitude']=0 },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['BlueZone']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=37.0,['latitude']=34.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['wasBlue']=true,['triggers']={ ['missioncompleted']=0 } },
+    ['NeutralZone1']={ ['upgradesUsed']=0,['side']=0,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=38.0,['latitude']=35.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=0,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } },
+    ['NeutralZone2']={ ['upgradesUsed']=0,['side']=0,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['lat_long']={ ['longitude']=39.0,['latitude']=36.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=0,['wasBlue']=false,['triggers']={ ['missioncompleted']=0 } }
+}
+zonePersistance['playerStats'] = { }

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -94,7 +94,7 @@ def test_sitac_campaign_progress_with_neutral() -> None:
     """Inactive neutral zones are excluded from progress calculation"""
     lua_path = Path("tests/fixtures/test_progress/foothold_with_neutral.lua")
     sitac = load_sitac(lua_path)
-    # 1 red, 1 blue (inactive neutral excluded) = (2-1)/2 = 50%
+    # 1 red, 1 blue (inactive neutral excluded) = 1/(1+1) = 50%
     assert sitac.campaign_progress == 50.0
 
 
@@ -103,7 +103,15 @@ def test_sitac_campaign_progress_excludes_hidden() -> None:
     lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
     sitac = load_sitac(lua_path)
     # Zones visibles: VisibleZone1 (rouge), VisibleZone2 (bleu)
-    # = (2-1)/2 = 50%
+    # = 1/(1+1) = 50%
+    assert sitac.campaign_progress == 50.0
+
+
+def test_sitac_campaign_progress_with_active_neutral() -> None:
+    """Active neutral zones are ignored in progress calculation"""
+    lua_path = Path("tests/fixtures/test_progress/foothold_with_active_neutral.lua")
+    sitac = load_sitac(lua_path)
+    # 1 red, 1 blue, 2 neutral (active but ignored) = 1/(1+1) = 50%
     assert sitac.campaign_progress == 50.0
 
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust campaign progress calculation to be based on the proportion of blue vs red visible zones while ignoring neutral zones, and update tests and documentation accordingly.

Bug Fixes:
- Correct campaign progress formula to use the ratio of blue to contested (blue + red) visible zones instead of relying on total visible zones.

Enhancements:
- Clarify campaign progress behavior to ignore neutral zones, including when active, in both code and tests.

Documentation:
- Update local run instructions to use Poetry for executing the web server.

Tests:
- Add and update unit tests and Lua fixtures to validate campaign progress with hidden, neutral, and active neutral zones.