### PR TITLE
Add zone popup group list from groupStatus in map payload

### DIFF
--- a/src/foothold_sitac/foothold.py
+++ b/src/foothold_sitac/foothold.py
@@ -38,6 +38,7 @@ class Zone(BaseModel):
     hidden: bool = False
     flavor_text: str | None = Field(alias="flavorText", default=None)
     group_status: list[ZoneGroupStatusEntry] | None = Field(alias="groupStatus", default=None)
+    group_status_max: int | None = Field(alias="groupStatusMax", default=None)
 
     @field_validator("group_status", mode="before")
     @classmethod

--- a/src/foothold_sitac/foothold_api_router.py
+++ b/src/foothold_sitac/foothold_api_router.py
@@ -41,6 +41,7 @@ async def foothold_get_map_data(
                 "units": zone.total_units,
                 "level": zone.level,
                 "flavor_text": zone.flavor_text,
+                "group_status_max": zone.group_status_max,
                 "group_status": [
                     MapZoneGroupStatusEntry.model_validate(
                         {

--- a/src/foothold_sitac/schemas.py
+++ b/src/foothold_sitac/schemas.py
@@ -22,6 +22,7 @@ class MapZone(BaseModel):
     level: int
     flavor_text: str | None = None
     group_status: list[MapZoneGroupStatusEntry] = Field(default_factory=list)
+    group_status_max: int | None = None
 
 
 class MapConnection(BaseModel):

--- a/src/foothold_sitac/static/js/map.js
+++ b/src/foothold_sitac/static/js/map.js
@@ -123,6 +123,9 @@ function openZoneModal(zone) {
     var formattedLat = formatCoord(zone.lat, true);
     var formattedLon = formatCoord(zone.lon, false);
     var groups = Array.isArray(zone.group_status) ? zone.group_status : [];
+    var hasMax = typeof zone.group_status_max === 'number' && isFinite(zone.group_status_max);
+    var groupsMax = hasMax ? Math.max(zone.group_status_max, groups.length) : groups.length;
+    var groupsHeaderText = 'Groups (' + groups.length + '/' + groupsMax + ')';
     function makeCell(text, rightAlign) {
         var td = document.createElement('td');
         td.style.padding = '8px 0';
@@ -177,7 +180,7 @@ function openZoneModal(zone) {
     var groupsHeader = document.createElement('div');
     groupsHeader.style.paddingBottom = '6px';
     groupsHeader.style.color = '#8892a0';
-    groupsHeader.textContent = 'Groups';
+    groupsHeader.textContent = groupsHeaderText;
     groupsContainer.appendChild(groupsHeader);
 
     if (groups.length > 0) {

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -66,6 +66,8 @@ def test_map_data_group_status_default_empty(client: TestClient) -> None:
     for zone in data["zones"]:
         assert "group_status" in zone
         assert isinstance(zone["group_status"], list)
+        assert "group_status_max" in zone
+        assert zone["group_status_max"] is None or isinstance(zone["group_status_max"], int)
 
 
 def test_sitac_includes_hidden_zones(client: TestClient) -> None:

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -193,6 +193,7 @@ def test_zone_flavor_text_default(base_zone_data: dict[str, Any]) -> None:
 
 def test_zone_group_status_parses_lua_table(base_zone_data: dict[str, Any]) -> None:
     """Test Zone model with groupStatus as Lua-style table"""
+    base_zone_data["groupStatusMax"] = 5
     base_zone_data["groupStatus"] = {
         1: {"name": "Red SAM SA-2", "kind": "group"},
         2: {"name": "Enemy Armour Group 2", "kind": "group", "damaged": True},
@@ -206,12 +207,14 @@ def test_zone_group_status_parses_lua_table(base_zone_data: dict[str, Any]) -> N
     assert zone.group_status[0].damaged is None
     assert zone.group_status[1].damaged is True
     assert zone.group_status[2].kind == "static"
+    assert zone.group_status_max == 5
 
 
 def test_zone_group_status_default_none(base_zone_data: dict[str, Any]) -> None:
     """Test Zone model without groupStatus (default to None)"""
     zone = Zone.model_validate(base_zone_data)
     assert zone.group_status is None
+    assert zone.group_status_max is None
 
 
 def test_load_sitac_with_flavor_text() -> None:


### PR DESCRIPTION
Added groups.

## Summary by Sourcery

Expose zone group status data from the backend to the map API and render it in the zone popup.

New Features:
- Display a scrollable list of zone groups, including type and damaged status, in the map zone popup when group status data is present.

Enhancements:
- Normalize and parse Lua-style groupStatus data into structured zone group status entries in the domain model and API schema.
- Ensure map API responses always include a group_status field for zones as a list, defaulting to empty when no data is available.

Tests:
- Add unit tests for Zone.group_status parsing and defaults, and integration tests verifying group_status presence in map API responses.