### PR TITLE
Add ratio columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Add ratio columns (Pts/Death, Air K/D, Ground K/D) and icon headers with tooltips to ranking board ([#107](https://github.com/VEAF/foothold-sitac/issues/107))
 - Display remaining units on objectives ([#103](https://github.com/VEAF/foothold-sitac/issues/103))
 - Display coalition credits ([#102](https://github.com/VEAF/foothold-sitac/pull/102))
 

--- a/src/foothold_sitac/static/css/modals.css
+++ b/src/foothold_sitac/static/css/modals.css
@@ -71,6 +71,7 @@
 #modal-body {
     flex: 1;
     overflow-y: auto;
+    overflow-x: hidden;
 }
 
 /* Loading state */
@@ -131,6 +132,77 @@
 
 .modal-table td {
     color: var(--text-secondary);
+}
+
+/* Players table - compact padding for 11 columns */
+.modal-table.players th,
+.modal-table.players td {
+    padding: 10px 8px;
+}
+
+/* Icon headers - centered with tooltip */
+.modal-table th.col-icon {
+    text-align: center;
+    cursor: help;
+    position: relative;
+}
+
+.modal-table th.col-icon::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1a1d23;
+    color: #e2e8f0;
+    padding: 5px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.modal-table th.col-icon:hover::after,
+.modal-table th.col-icon.tooltip-active::after {
+    opacity: 1;
+}
+
+/* Value cell tooltips */
+.modal-table td[data-tooltip] {
+    position: relative;
+    cursor: help;
+}
+
+.modal-table td[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1a1d23;
+    color: #e2e8f0;
+    padding: 5px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.modal-table td[data-tooltip]:hover::after,
+.modal-table td[data-tooltip].tooltip-active::after {
+    opacity: 1;
 }
 
 /* Player rankings - podium colors (only for players table) */

--- a/src/foothold_sitac/static/css/sitac.css
+++ b/src/foothold_sitac/static/css/sitac.css
@@ -51,6 +51,68 @@
     font-weight: 600;
 }
 
+.sitac-table th.col-icon {
+    text-align: center;
+    cursor: help;
+    position: relative;
+}
+
+.sitac-table th.col-icon::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1a1d23;
+    color: #e2e8f0;
+    padding: 5px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.sitac-table th.col-icon:hover::after,
+.sitac-table th.col-icon.tooltip-active::after {
+    opacity: 1;
+}
+
+/* Value cell tooltips */
+.sitac-table td[data-tooltip] {
+    position: relative;
+    cursor: help;
+}
+
+.sitac-table td[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1a1d23;
+    color: #e2e8f0;
+    padding: 5px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.sitac-table td[data-tooltip]:hover::after,
+.sitac-table td[data-tooltip].tooltip-active::after {
+    opacity: 1;
+}
+
 .sitac-table tr:nth-child(even) {
     background: #fafbfc;
 }

--- a/src/foothold_sitac/static/js/modals.js
+++ b/src/foothold_sitac/static/js/modals.js
@@ -25,6 +25,11 @@ function openModal(type) {
                 newScript.textContent = oldScript.textContent;
                 oldScript.parentNode.replaceChild(newScript, oldScript);
             });
+
+            // Initialize tooltips on dynamically loaded content
+            if (typeof initTooltips === 'function') {
+                initTooltips(body);
+            }
         })
         .catch(function(error) {
             body.innerHTML = '<div class="modal-loading">Error loading data</div>';

--- a/src/foothold_sitac/static/js/tooltips.js
+++ b/src/foothold_sitac/static/js/tooltips.js
@@ -1,36 +1,24 @@
-/* Tooltips JS - Click support for mobile devices */
+/* Tooltips JS - Click support for mobile devices (single delegated listener) */
 
-function initTooltips(container) {
-    var root = container || document;
-    var selector = '[data-tooltip]';
-
-    root.querySelectorAll(selector).forEach(function(el) {
-        el.addEventListener('click', function(e) {
-            var wasActive = el.classList.contains('tooltip-active');
-            // Close all tooltips first
-            root.querySelectorAll('.tooltip-active').forEach(function(other) {
-                other.classList.remove('tooltip-active');
-            });
-            // Toggle clicked tooltip
-            if (!wasActive) {
-                el.classList.add('tooltip-active');
-            }
+document.addEventListener('click', function(e) {
+    var target = e.target.closest('[data-tooltip]');
+    if (target) {
+        var wasActive = target.classList.contains('tooltip-active');
+        // Close all tooltips first
+        document.querySelectorAll('.tooltip-active').forEach(function(el) {
+            el.classList.remove('tooltip-active');
         });
-    });
-
-    // Close tooltips when clicking elsewhere
-    document.addEventListener('click', function(e) {
-        if (!e.target.closest(selector)) {
-            root.querySelectorAll('.tooltip-active').forEach(function(el) {
-                el.classList.remove('tooltip-active');
-            });
+        // Toggle clicked tooltip
+        if (!wasActive) {
+            target.classList.add('tooltip-active');
         }
-    });
-}
+    } else {
+        // Clicked outside any tooltip element — close all
+        document.querySelectorAll('.tooltip-active').forEach(function(el) {
+            el.classList.remove('tooltip-active');
+        });
+    }
+});
 
-// Auto-init for standalone pages
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function() { initTooltips(); });
-} else {
-    initTooltips();
-}
+// Keep initTooltips as a no-op for backward compatibility with modals.js
+function initTooltips() {}

--- a/src/foothold_sitac/static/js/tooltips.js
+++ b/src/foothold_sitac/static/js/tooltips.js
@@ -1,0 +1,36 @@
+/* Tooltips JS - Click support for mobile devices */
+
+function initTooltips(container) {
+    var root = container || document;
+    var selector = '[data-tooltip]';
+
+    root.querySelectorAll(selector).forEach(function(el) {
+        el.addEventListener('click', function(e) {
+            var wasActive = el.classList.contains('tooltip-active');
+            // Close all tooltips first
+            root.querySelectorAll('.tooltip-active').forEach(function(other) {
+                other.classList.remove('tooltip-active');
+            });
+            // Toggle clicked tooltip
+            if (!wasActive) {
+                el.classList.add('tooltip-active');
+            }
+        });
+    });
+
+    // Close tooltips when clicking elsewhere
+    document.addEventListener('click', function(e) {
+        if (!e.target.closest(selector)) {
+            root.querySelectorAll('.tooltip-active').forEach(function(el) {
+                el.classList.remove('tooltip-active');
+            });
+        }
+    });
+}
+
+// Auto-init for standalone pages
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function() { initTooltips(); });
+} else {
+    initTooltips();
+}

--- a/src/foothold_sitac/templates/foothold/map.html
+++ b/src/foothold_sitac/templates/foothold/map.html
@@ -105,6 +105,7 @@
 {% block scripts %}
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="{{ static_url('js/coords.js') }}"></script>
+<script src="{{ static_url('js/tooltips.js') }}"></script>
 <script src="{{ static_url('js/modals.js') }}"></script>
 <script src="{{ static_url('js/map.js') }}"></script>
 <script>

--- a/src/foothold_sitac/templates/foothold/partials/players.html
+++ b/src/foothold_sitac/templates/foothold/partials/players.html
@@ -4,12 +4,15 @@
         <tr>
             <th>#</th>
             <th>Player</th>
-            <th>Points</th>
-            <th>Deaths</th>
-            <th>Zone Captures</th>
-            <th>Zone Upgrades</th>
-            <th>Air</th>
-            <th>Ground Units</th>
+            <th class="col-icon" data-tooltip="Points"><i class="fa-solid fa-star"></i></th>
+            <th class="col-icon" data-tooltip="Deaths"><i class="fa-solid fa-skull"></i></th>
+            <th class="col-icon" data-tooltip="Points per Death"><i class="fa-solid fa-chart-line"></i></th>
+            <th class="col-icon" data-tooltip="Zone Captures"><i class="fa-solid fa-flag"></i></th>
+            <th class="col-icon" data-tooltip="Zone Upgrades"><i class="fa-solid fa-arrow-up"></i></th>
+            <th class="col-icon" data-tooltip="Air Kills (A/A)"><i class="fa-solid fa-jet-fighter"></i></th>
+            <th class="col-icon" data-tooltip="Ground Kills (A/G)"><i class="fa-solid fa-crosshairs"></i></th>
+            <th class="col-icon" data-tooltip="Air Kill/Death Ratio"><i class="fa-solid fa-plane-slash"></i></th>
+            <th class="col-icon" data-tooltip="Ground Kill/Death Ratio"><i class="fa-solid fa-explosion"></i></th>
         </tr>
     </thead>
     <tbody>
@@ -17,16 +20,19 @@
         <tr>
             <td class="n">{{ loop.index }}</td>
             <td>{{ player }}</td>
-            <td class="n">{{ stats.points | int }}</td>
-            <td class="n">{{ stats.deaths }}</td>
-            <td class="n">{{ stats.zone_capture }}</td>
-            <td class="n">{{ stats.zone_upgrade }}</td>
-            <td class="n">{{ stats.air }}</td>
-            <td class="n">{{ stats.ground_units }}</td>
+            <td class="n" data-tooltip="Points">{{ stats.points | int }}</td>
+            <td class="n" data-tooltip="Deaths">{{ stats.deaths }}</td>
+            <td class="n" data-tooltip="Points per Death">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
+            <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
+            <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
+            <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
+            <td class="n" data-tooltip="Air Kill/Death Ratio">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-tooltip="Ground Kill/Death Ratio">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
         </tr>
         {% else %}
         <tr>
-            <td colspan="8" style="text-align: center; color: #5a6270;">No player data available</td>
+            <td colspan="11" style="text-align: center; color: #5a6270;">No player data available</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/src/foothold_sitac/templates/foothold/sitac.html
+++ b/src/foothold_sitac/templates/foothold/sitac.html
@@ -4,6 +4,9 @@
 
 {% block styles %}
 <link rel="stylesheet" href="{{ static_url('css/sitac.css') }}">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
+      integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw=="
+      crossorigin="anonymous" referrerpolicy="no-referrer" />
 {% endblock %}
 
 {% block body_class %}sitac-page{% endblock %}
@@ -54,12 +57,15 @@
             <tr>
                 <th>#</th>
                 <th>Player</th>
-                <th>Points</th>
-                <th>Deaths</th>
-                <th>Zone Captures</th>
-                <th>Zone Upgrades</th>
-                <th>Air</th>
-                <th>Ground Units</th>
+                <th class="col-icon" data-tooltip="Points"><i class="fa-solid fa-star"></i></th>
+                <th class="col-icon" data-tooltip="Deaths"><i class="fa-solid fa-skull"></i></th>
+                <th class="col-icon" data-tooltip="Points per Death"><i class="fa-solid fa-chart-line"></i></th>
+                <th class="col-icon" data-tooltip="Zone Captures"><i class="fa-solid fa-flag"></i></th>
+                <th class="col-icon" data-tooltip="Zone Upgrades"><i class="fa-solid fa-arrow-up"></i></th>
+                <th class="col-icon" data-tooltip="Air Kills (A/A)"><i class="fa-solid fa-jet-fighter"></i></th>
+                <th class="col-icon" data-tooltip="Ground Kills (A/G)"><i class="fa-solid fa-crosshairs"></i></th>
+                <th class="col-icon" data-tooltip="Air Kill/Death Ratio"><i class="fa-solid fa-plane-slash"></i></th>
+                <th class="col-icon" data-tooltip="Ground Kill/Death Ratio"><i class="fa-solid fa-explosion"></i></th>
             </tr>
         </thead>
         <tbody>
@@ -67,12 +73,15 @@
             <tr>
                 <td class="n">{{ loop.index }}</td>
                 <td>{{ player }}</td>
-                <td class="n">{{ stats.points | int }}</td>
-                <td class="n">{{ stats.deaths }}</td>
-                <td class="n">{{ stats.zone_capture }}</td>
-                <td class="n">{{ stats.zone_upgrade }}</td>
-                <td class="n">{{ stats.air }}</td>
-                <td class="n">{{ stats.ground_units }}</td>
+                <td class="n" data-tooltip="Points">{{ stats.points | int }}</td>
+                <td class="n" data-tooltip="Deaths">{{ stats.deaths }}</td>
+                <td class="n" data-tooltip="Points per Death">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
+                <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
+                <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
+                <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
+                <td class="n" data-tooltip="Air Kill/Death Ratio">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-tooltip="Ground Kill/Death Ratio">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -82,4 +91,8 @@
         <a href="{{ request.url_for('foothold_servers') }}" class="sitac-back-btn">Back to servers list</a>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ static_url('js/tooltips.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary by Sourcery

Add new ratio-based player stats columns and icon-based headers with tooltips to SITAC player tables, including mobile-friendly tooltip behavior.

New Features:
- Introduce ratio columns for points per death, air kill/death, and ground kill/death in player rankings and SITAC stats tables.
- Add icon-based table headers with descriptive tooltips for player stat columns.
- Implement a reusable tooltip initialization script supporting click-to-toggle behavior, including for dynamically loaded modal content.

Enhancements:
- Adjust player modal table padding and constrain horizontal overflow in modal bodies for better layout with additional columns.
- Apply consistent tooltip styling for table headers and cells in SITAC and modal views.

Documentation:
- Update changelog to record the addition of ratio columns and tooltip-enhanced icon headers to the ranking board.