### PR TITLE
Feature/108 add ranking table sort columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- Add column sorting to ranking table ([#108](https://github.com/VEAF/foothold-sitac/issues/108))
+- Add column sorting to ranking table and reorder columns to place ratios next to their related values ([#108](https://github.com/VEAF/foothold-sitac/issues/108))
 - Add ratio columns (Pts/Death, Air K/D, Ground K/D) and icon headers with tooltips to ranking board ([#107](https://github.com/VEAF/foothold-sitac/issues/107))
 - Display remaining units on objectives ([#103](https://github.com/VEAF/foothold-sitac/issues/103))
 - Display coalition credits ([#102](https://github.com/VEAF/foothold-sitac/pull/102))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Add column sorting to ranking table ([#108](https://github.com/VEAF/foothold-sitac/issues/108))
 - Add ratio columns (Pts/Death, Air K/D, Ground K/D) and icon headers with tooltips to ranking board ([#107](https://github.com/VEAF/foothold-sitac/issues/107))
 - Display remaining units on objectives ([#103](https://github.com/VEAF/foothold-sitac/issues/103))
 - Display coalition credits ([#102](https://github.com/VEAF/foothold-sitac/pull/102))

--- a/src/foothold_sitac/static/css/modals.css
+++ b/src/foothold_sitac/static/css/modals.css
@@ -140,6 +140,33 @@
     padding: 10px 8px;
 }
 
+/* Sortable column headers */
+th[data-sort-key] {
+    cursor: pointer;
+    user-select: none;
+}
+
+th[data-sort-key]:hover {
+    background: rgba(66, 99, 235, 0.25);
+}
+
+th[data-sort-key]::before {
+    font-size: 10px;
+    margin-right: 4px;
+    opacity: 0.4;
+    content: '\2195';
+}
+
+th[data-sort-key].sort-asc::before {
+    content: '\2191';
+    opacity: 1;
+}
+
+th[data-sort-key].sort-desc::before {
+    content: '\2193';
+    opacity: 1;
+}
+
 /* Icon headers - centered with tooltip */
 .modal-table th.col-icon {
     text-align: center;

--- a/src/foothold_sitac/static/js/table-sort.js
+++ b/src/foothold_sitac/static/js/table-sort.js
@@ -1,0 +1,57 @@
+/* Table Sort JS - Client-side column sorting for ranking tables */
+
+function initTableSort(table) {
+    var headers = table.querySelectorAll('th[data-sort-key]');
+    headers.forEach(function(th) {
+        th.addEventListener('click', function() {
+            sortTable(table, th);
+        });
+    });
+}
+
+function sortTable(table, th) {
+    var tbody = table.querySelector('tbody');
+    var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+    var colIndex = Array.prototype.indexOf.call(th.parentNode.children, th);
+    var sortType = th.getAttribute('data-sort-type') || 'number';
+
+    // Determine sort direction
+    var isAsc = th.classList.contains('sort-desc');
+    var allHeaders = table.querySelectorAll('th[data-sort-key]');
+    allHeaders.forEach(function(h) {
+        h.classList.remove('sort-asc', 'sort-desc');
+    });
+    th.classList.add(isAsc ? 'sort-asc' : 'sort-desc');
+
+    rows.sort(function(a, b) {
+        var cellA = a.children[colIndex];
+        var cellB = b.children[colIndex];
+        var valA, valB;
+
+        if (sortType === 'string') {
+            valA = cellA.textContent.trim();
+            valB = cellB.textContent.trim();
+            var cmp = valA.localeCompare(valB);
+            return isAsc ? cmp : -cmp;
+        }
+
+        // Numeric: use data-sort-value if present, otherwise parse text
+        valA = cellA.hasAttribute('data-sort-value')
+            ? parseFloat(cellA.getAttribute('data-sort-value'))
+            : parseFloat(cellA.textContent);
+        valB = cellB.hasAttribute('data-sort-value')
+            ? parseFloat(cellB.getAttribute('data-sort-value'))
+            : parseFloat(cellB.textContent);
+
+        if (isNaN(valA)) valA = -Infinity;
+        if (isNaN(valB)) valB = -Infinity;
+
+        return isAsc ? valA - valB : valB - valA;
+    });
+
+    // Re-append sorted rows and update rank numbers
+    rows.forEach(function(row, i) {
+        tbody.appendChild(row);
+        row.children[0].textContent = i + 1;
+    });
+}

--- a/src/foothold_sitac/static/js/table-sort.js
+++ b/src/foothold_sitac/static/js/table-sort.js
@@ -1,6 +1,8 @@
 /* Table Sort JS - Client-side column sorting for ranking tables */
 
 function initTableSort(table) {
+    if (table.dataset.sortInitialized) return;
+    table.dataset.sortInitialized = 'true';
     var headers = table.querySelectorAll('th[data-sort-key]');
     headers.forEach(function(th) {
         th.addEventListener('click', function() {

--- a/src/foothold_sitac/static/js/tooltips.js
+++ b/src/foothold_sitac/static/js/tooltips.js
@@ -2,7 +2,7 @@
 
 document.addEventListener('click', function(e) {
     var target = e.target.closest('[data-tooltip]');
-    if (target) {
+    if (target && !target.hasAttribute('data-sort-key')) {
         var wasActive = target.classList.contains('tooltip-active');
         // Close all tooltips first
         document.querySelectorAll('.tooltip-active').forEach(function(el) {

--- a/src/foothold_sitac/templates/foothold/map.html
+++ b/src/foothold_sitac/templates/foothold/map.html
@@ -107,6 +107,7 @@
 <script src="{{ static_url('js/coords.js') }}"></script>
 <script src="{{ static_url('js/tooltips.js') }}"></script>
 <script src="{{ static_url('js/modals.js') }}"></script>
+<script src="{{ static_url('js/table-sort.js') }}"></script>
 <script src="{{ static_url('js/map.js') }}"></script>
 <script>
     // Set modal endpoints

--- a/src/foothold_sitac/templates/foothold/partials/players.html
+++ b/src/foothold_sitac/templates/foothold/partials/players.html
@@ -1,18 +1,18 @@
 <h2>Player Rankings</h2>
-<table class="modal-table players">
+<table class="modal-table players sortable">
     <thead>
         <tr>
             <th>#</th>
-            <th>Player</th>
-            <th class="col-icon" data-tooltip="Points"><i class="fa-solid fa-star"></i></th>
-            <th class="col-icon" data-tooltip="Deaths"><i class="fa-solid fa-skull"></i></th>
-            <th class="col-icon" data-tooltip="Points per Death"><i class="fa-solid fa-chart-line"></i></th>
-            <th class="col-icon" data-tooltip="Zone Captures"><i class="fa-solid fa-flag"></i></th>
-            <th class="col-icon" data-tooltip="Zone Upgrades"><i class="fa-solid fa-arrow-up"></i></th>
-            <th class="col-icon" data-tooltip="Air Kills (A/A)"><i class="fa-solid fa-jet-fighter"></i></th>
-            <th class="col-icon" data-tooltip="Ground Kills (A/G)"><i class="fa-solid fa-crosshairs"></i></th>
-            <th class="col-icon" data-tooltip="Air Kill/Death Ratio"><i class="fa-solid fa-plane-slash"></i></th>
-            <th class="col-icon" data-tooltip="Ground Kill/Death Ratio"><i class="fa-solid fa-explosion"></i></th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
+            <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
+            <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
+            <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
+            <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
+            <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
+            <th class="col-icon" data-tooltip="Ground Kills (A/G)" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
+            <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-plane-slash"></i></th>
+            <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-explosion"></i></th>
         </tr>
     </thead>
     <tbody>
@@ -22,13 +22,13 @@
             <td>{{ player }}</td>
             <td class="n" data-tooltip="Points">{{ stats.points | int }}</td>
             <td class="n" data-tooltip="Deaths">{{ stats.deaths }}</td>
-            <td class="n" data-tooltip="Points per Death">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-tooltip="Points per Death" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
             <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
             <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
             <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
             <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
-            <td class="n" data-tooltip="Air Kill/Death Ratio">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
-            <td class="n" data-tooltip="Ground Kill/Death Ratio">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-tooltip="Air Kill/Death Ratio" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-tooltip="Ground Kill/Death Ratio" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
         </tr>
         {% else %}
         <tr>
@@ -37,3 +37,11 @@
         {% endfor %}
     </tbody>
 </table>
+<script>
+    (function() {
+        var table = document.querySelector('.modal-table.players.sortable');
+        if (table && typeof initTableSort === 'function') {
+            initTableSort(table);
+        }
+    })();
+</script>

--- a/src/foothold_sitac/templates/foothold/partials/players.html
+++ b/src/foothold_sitac/templates/foothold/partials/players.html
@@ -10,9 +10,9 @@
             <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
             <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
             <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
+            <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
             <th class="col-icon" data-tooltip="Ground Kills (A/G)" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
-            <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-plane-slash"></i></th>
-            <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-explosion"></i></th>
+            <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
         </tr>
     </thead>
     <tbody>
@@ -26,8 +26,8 @@
             <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
             <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
             <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
-            <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
             <td class="n" data-tooltip="Air Kill/Death Ratio" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
             <td class="n" data-tooltip="Ground Kill/Death Ratio" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
         </tr>
         {% else %}

--- a/src/foothold_sitac/templates/foothold/sitac.html
+++ b/src/foothold_sitac/templates/foothold/sitac.html
@@ -52,20 +52,20 @@
 
     <!-- Section PLAYER STATS -->
     <h2>Player Stats</h2>
-    <table class="sitac-table">
+    <table class="sitac-table sortable">
         <thead>
             <tr>
                 <th>#</th>
-                <th>Player</th>
-                <th class="col-icon" data-tooltip="Points"><i class="fa-solid fa-star"></i></th>
-                <th class="col-icon" data-tooltip="Deaths"><i class="fa-solid fa-skull"></i></th>
-                <th class="col-icon" data-tooltip="Points per Death"><i class="fa-solid fa-chart-line"></i></th>
-                <th class="col-icon" data-tooltip="Zone Captures"><i class="fa-solid fa-flag"></i></th>
-                <th class="col-icon" data-tooltip="Zone Upgrades"><i class="fa-solid fa-arrow-up"></i></th>
-                <th class="col-icon" data-tooltip="Air Kills (A/A)"><i class="fa-solid fa-jet-fighter"></i></th>
-                <th class="col-icon" data-tooltip="Ground Kills (A/G)"><i class="fa-solid fa-crosshairs"></i></th>
-                <th class="col-icon" data-tooltip="Air Kill/Death Ratio"><i class="fa-solid fa-plane-slash"></i></th>
-                <th class="col-icon" data-tooltip="Ground Kill/Death Ratio"><i class="fa-solid fa-explosion"></i></th>
+                <th data-sort-key="player" data-sort-type="string">Player</th>
+                <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
+                <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
+                <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
+                <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
+                <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
+                <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
+                <th class="col-icon" data-tooltip="Ground Kills (A/G)" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
+                <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-plane-slash"></i></th>
+                <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-explosion"></i></th>
             </tr>
         </thead>
         <tbody>
@@ -75,13 +75,13 @@
                 <td>{{ player }}</td>
                 <td class="n" data-tooltip="Points">{{ stats.points | int }}</td>
                 <td class="n" data-tooltip="Deaths">{{ stats.deaths }}</td>
-                <td class="n" data-tooltip="Points per Death">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-tooltip="Points per Death" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
                 <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
                 <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
                 <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
                 <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
-                <td class="n" data-tooltip="Air Kill/Death Ratio">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
-                <td class="n" data-tooltip="Ground Kill/Death Ratio">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-tooltip="Air Kill/Death Ratio" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-tooltip="Ground Kill/Death Ratio" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -95,4 +95,8 @@
 
 {% block scripts %}
 <script src="{{ static_url('js/tooltips.js') }}"></script>
+<script src="{{ static_url('js/table-sort.js') }}"></script>
+<script>
+    document.querySelectorAll('.sitac-table.sortable').forEach(initTableSort);
+</script>
 {% endblock %}

--- a/src/foothold_sitac/templates/foothold/sitac.html
+++ b/src/foothold_sitac/templates/foothold/sitac.html
@@ -63,9 +63,9 @@
                 <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
                 <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
                 <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
+                <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
                 <th class="col-icon" data-tooltip="Ground Kills (A/G)" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
-                <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-plane-slash"></i></th>
-                <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-explosion"></i></th>
+                <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
             </tr>
         </thead>
         <tbody>
@@ -79,8 +79,8 @@
                 <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
                 <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
                 <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
-                <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
                 <td class="n" data-tooltip="Air Kill/Death Ratio" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
                 <td class="n" data-tooltip="Ground Kill/Death Ratio" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary by Sourcery

Add client-side sortable columns to player ranking and stats tables and update related assets.

New Features:
- Enable client-side sorting on player ranking and stats tables using a reusable table-sort script.

Enhancements:
- Reorder player stats columns to group kill/death ratios next to their related metrics and adjust icons to reflect ratio columns.
- Style sortable table headers with visual sort indicators and prevent tooltips from triggering on sortable headers.

Documentation:
- Update changelog to document the new ranking table column sorting feature.