### PR TITLE
Feature/113 add more metrics to ranking table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Add all missing player metrics and reorganize ranking table into category tabs: General, Air to Air, SEAD, CAS, Strike, Logistic, CSAR, Recon ([#113](https://github.com/VEAF/foothold-sitac/issues/113))
 - Add column sorting to ranking table and reorder columns to place ratios next to their related values ([#108](https://github.com/VEAF/foothold-sitac/issues/108))
 - Add ratio columns (Pts/Death, Air K/D, Ground K/D) and icon headers with tooltips to ranking board ([#107](https://github.com/VEAF/foothold-sitac/issues/107))
 - Display remaining units on objectives ([#103](https://github.com/VEAF/foothold-sitac/issues/103))

--- a/src/foothold_sitac/foothold.py
+++ b/src/foothold_sitac/foothold.py
@@ -116,6 +116,14 @@ class PlayerStats(BaseModel):
     infantry: int = Field(alias="Infantry", default=0)
     ground_units: int = Field(alias="Ground Units", default=0)
     helo: int = Field(alias="Helo", default=0)
+    structure: int = Field(alias="Structure", default=0)
+    CAP_mission: int = Field(alias="CAP mission", default=0)
+    recon_mission: int = Field(alias="Recon mission", default=0)
+    pilot_rescue: int = Field(alias="Pilot Rescue", default=0)
+    flight_time: float = Field(alias="Flight time", default=0)
+    warehouse_delivery: int = Field(alias="Warehouse delivery", default=0)
+    bomb_runway: int = Field(alias="Bomb runway", default=0)
+    intercept_cargo_plane: int = Field(alias="Intercept cargo plane", default=0)
 
 
 class Accounts(BaseModel):

--- a/src/foothold_sitac/static/css/modals.css
+++ b/src/foothold_sitac/static/css/modals.css
@@ -134,10 +134,18 @@
     color: var(--text-secondary);
 }
 
-/* Players table - compact padding for 11 columns */
+/* Players table - compact padding */
 .modal-table.players th,
 .modal-table.players td {
     padding: 10px 8px;
+}
+
+/* Fixed rank column width */
+.modal-table .col-rank {
+    width: 40px;
+    min-width: 40px;
+    max-width: 40px;
+    text-align: center !important;
 }
 
 /* Sortable column headers */

--- a/src/foothold_sitac/static/css/sitac.css
+++ b/src/foothold_sitac/static/css/sitac.css
@@ -192,3 +192,11 @@
 .sitac-container .tab-content.active {
     display: block;
 }
+
+/* Fixed rank column width */
+.col-rank {
+    width: 40px;
+    min-width: 40px;
+    max-width: 40px;
+    text-align: center !important;
+}

--- a/src/foothold_sitac/static/css/sitac.css
+++ b/src/foothold_sitac/static/css/sitac.css
@@ -7,7 +7,7 @@
 }
 
 .sitac-container {
-    max-width: 900px;
+    max-width: 960px;
     margin: auto;
     background: white;
     border-radius: 12px;
@@ -151,4 +151,44 @@
 
 .side-badge.grey {
     background: #868e96;
+}
+
+/* Tabs for sitac page (light theme) */
+.sitac-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 20px;
+    border-bottom: 2px solid #e9ecef;
+    padding-bottom: 0;
+    flex-wrap: wrap;
+}
+
+.sitac-tabs .tab-btn {
+    padding: 8px 14px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    color: #868e96;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.sitac-tabs .tab-btn:hover {
+    color: #495057;
+}
+
+.sitac-tabs .tab-btn.active {
+    color: #274bde;
+    border-bottom-color: #274bde;
+}
+
+.sitac-container .tab-content {
+    display: none;
+}
+
+.sitac-container .tab-content.active {
+    display: block;
 }

--- a/src/foothold_sitac/templates/foothold/partials/players.html
+++ b/src/foothold_sitac/templates/foothold/partials/players.html
@@ -1,47 +1,258 @@
 <h2>Player Rankings</h2>
+
+<div class="tabs ranking-tabs">
+    <button class="tab-btn active" data-tab="general">General</button>
+    <button class="tab-btn" data-tab="air">Air to Air</button>
+    <button class="tab-btn" data-tab="sead">SEAD</button>
+    <button class="tab-btn" data-tab="cas">CAS</button>
+    <button class="tab-btn" data-tab="strike">Strike</button>
+    <button class="tab-btn" data-tab="logistic">Logistic</button>
+    <button class="tab-btn" data-tab="csar">CSAR</button>
+    <button class="tab-btn" data-tab="recon">Recon</button>
+</div>
+
+{% macro player_rows(sort_attr, cols) %}
+{% for player, stats in sitac.player_stats.items() | sort(attribute='1.' + sort_attr, reverse=True) %}
+<tr>
+    <td class="n">{{ loop.index }}</td>
+    <td>{{ player }}</td>
+    {% for col in cols %}{{ col(stats) }}{% endfor %}
+</tr>
+{% else %}
+<tr><td colspan="99" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+{% endfor %}
+{% endmacro %}
+
+<!-- General -->
+<div class="tab-content active" data-tab-content="general">
 <table class="modal-table players sortable">
-    <thead>
-        <tr>
-            <th>#</th>
-            <th data-sort-key="player" data-sort-type="string">Player</th>
-            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
-            <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
-            <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
-            <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
-            <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
-            <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
-            <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
-            <th class="col-icon" data-tooltip="Ground Kills (A/G)" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
-            <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
-        </tr>
-    </thead>
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
+        <th class="col-icon" data-tooltip="Points Spent" data-sort-key="points_spent"><i class="fa-solid fa-coins"></i></th>
+        <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
+        <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
+    </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
         <tr>
             <td class="n">{{ loop.index }}</td>
             <td>{{ player }}</td>
-            <td class="n" data-tooltip="Points">{{ stats.points | int }}</td>
-            <td class="n" data-tooltip="Deaths">{{ stats.deaths }}</td>
-            <td class="n" data-tooltip="Points per Death" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
-            <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
-            <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
-            <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
-            <td class="n" data-tooltip="Air Kill/Death Ratio" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
-            <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
-            <td class="n" data-tooltip="Ground Kill/Death Ratio" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n">{{ stats.points | int }}</td>
+            <td class="n">{{ stats.points_spent | int }}</td>
+            <td class="n">{{ stats.deaths }}</td>
+            <td class="n" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
         </tr>
         {% else %}
-        <tr>
-            <td colspan="11" style="text-align: center; color: #5a6270;">No player data available</td>
-        </tr>
+        <tr><td colspan="6" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>
+</div>
+
+<!-- Air to Air -->
+<div class="tab-content" data-tab-content="air">
+<table class="modal-table players sortable">
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
+        <th class="col-icon" data-tooltip="Helicopter Kills" data-sort-key="helo"><i class="fa-solid fa-helicopter"></i></th>
+        <th class="col-icon" data-tooltip="Intercept Cargo Plane" data-sort-key="intercept"><i class="fa-solid fa-plane-circle-xmark"></i></th>
+        <th class="col-icon" data-tooltip="CAP Missions" data-sort-key="cap"><i class="fa-solid fa-shield-halved"></i></th>
+        <th class="col-icon" data-tooltip="Air K/D Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
+    </tr></thead>
+    <tbody>
+        {% for player, stats in sitac.player_stats.items() | sort(attribute='1.air', reverse=True) %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ player }}</td>
+            <td class="n">{{ stats.air }}</td>
+            <td class="n">{{ stats.helo }}</td>
+            <td class="n">{{ stats.intercept_cargo_plane }}</td>
+            <td class="n">{{ stats.CAP_mission }}</td>
+            <td class="n" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="7" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- SEAD -->
+<div class="tab-content" data-tab-content="sead">
+<table class="modal-table players sortable">
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="SAM/Air Defense Kills" data-sort-key="sam"><i class="fa-solid fa-explosion"></i></th>
+    </tr></thead>
+    <tbody>
+        {% for player, stats in sitac.player_stats.items() | sort(attribute='1.SAM', reverse=True) %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ player }}</td>
+            <td class="n">{{ stats.SAM }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- CAS -->
+<div class="tab-content" data-tab-content="cas">
+<table class="modal-table players sortable">
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Ground Unit Kills" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
+        <th class="col-icon" data-tooltip="Infantry Kills" data-sort-key="infantry"><i class="fa-solid fa-person-rifle"></i></th>
+        <th class="col-icon" data-tooltip="CAS Missions" data-sort-key="cas_mission"><i class="fa-solid fa-bullseye"></i></th>
+        <th class="col-icon" data-tooltip="Ground K/D Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
+    </tr></thead>
+    <tbody>
+        {% for player, stats in sitac.player_stats.items() | sort(attribute='1.ground_units', reverse=True) %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ player }}</td>
+            <td class="n">{{ stats.ground_units }}</td>
+            <td class="n">{{ stats.infantry }}</td>
+            <td class="n">{{ stats.CAS_mission }}</td>
+            <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="6" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- Strike -->
+<div class="tab-content" data-tab-content="strike">
+<table class="modal-table players sortable">
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Structure Kills" data-sort-key="structure"><i class="fa-solid fa-building"></i></th>
+        <th class="col-icon" data-tooltip="Bomb Runway" data-sort-key="bomb_runway"><i class="fa-solid fa-road"></i></th>
+    </tr></thead>
+    <tbody>
+        {% for player, stats in sitac.player_stats.items() | sort(attribute='1.structure', reverse=True) %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ player }}</td>
+            <td class="n">{{ stats.structure }}</td>
+            <td class="n">{{ stats.bomb_runway }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="4" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- Logistic -->
+<div class="tab-content" data-tab-content="logistic">
+<table class="modal-table players sortable">
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
+        <th class="col-icon" data-tooltip="Warehouse Deliveries" data-sort-key="warehouse"><i class="fa-solid fa-warehouse"></i></th>
+        <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
+        <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
+    </tr></thead>
+    <tbody>
+        {% for player, stats in sitac.player_stats.items() | sort(attribute='1.flight_time', reverse=True) %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ player }}</td>
+            <td class="n">{{ stats.flight_time | int }}</td>
+            <td class="n">{{ stats.warehouse_delivery }}</td>
+            <td class="n">{{ stats.zone_capture }}</td>
+            <td class="n">{{ stats.zone_upgrade }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="6" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- CSAR -->
+<div class="tab-content" data-tab-content="csar">
+<table class="modal-table players sortable">
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
+        <th class="col-icon" data-tooltip="Pilot Rescues" data-sort-key="pilot_rescue"><i class="fa-solid fa-parachute-box"></i></th>
+    </tr></thead>
+    <tbody>
+        {% for player, stats in sitac.player_stats.items() | sort(attribute='1.pilot_rescue', reverse=True) %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ player }}</td>
+            <td class="n">{{ stats.flight_time | int }}</td>
+            <td class="n">{{ stats.pilot_rescue }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="4" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- Recon -->
+<div class="tab-content" data-tab-content="recon">
+<table class="modal-table players sortable">
+    <thead><tr>
+        <th>#</th>
+        <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Recon Missions" data-sort-key="recon"><i class="fa-solid fa-binoculars"></i></th>
+    </tr></thead>
+    <tbody>
+        {% for player, stats in sitac.player_stats.items() | sort(attribute='1.recon_mission', reverse=True) %}
+        <tr>
+            <td class="n">{{ loop.index }}</td>
+            <td>{{ player }}</td>
+            <td class="n">{{ stats.recon_mission }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
 <script>
     (function() {
-        var table = document.querySelector('.modal-table.players.sortable');
-        if (table && typeof initTableSort === 'function') {
-            initTableSort(table);
+        // Tab switching
+        var container = document.querySelector('#modal-body') || document;
+        var tabBtns = container.querySelectorAll('.ranking-tabs .tab-btn');
+        tabBtns.forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                var tab = btn.getAttribute('data-tab');
+                tabBtns.forEach(function(b) { b.classList.remove('active'); });
+                btn.classList.add('active');
+                container.querySelectorAll('.tab-content').forEach(function(c) {
+                    c.classList.toggle('active', c.getAttribute('data-tab-content') === tab);
+                });
+                // Init sort on newly visible table
+                var activeTable = container.querySelector('.tab-content.active .sortable');
+                if (activeTable && typeof initTableSort === 'function') {
+                    initTableSort(activeTable);
+                }
+            });
+        });
+        // Init sort on the default active table
+        var activeTable = container.querySelector('.tab-content.active .sortable');
+        if (activeTable && typeof initTableSort === 'function') {
+            initTableSort(activeTable);
         }
     })();
 </script>

--- a/src/foothold_sitac/templates/foothold/partials/players.html
+++ b/src/foothold_sitac/templates/foothold/partials/players.html
@@ -1,33 +1,21 @@
 <h2>Player Rankings</h2>
 
 <div class="tabs ranking-tabs">
-    <button class="tab-btn active" data-tab="general">General</button>
-    <button class="tab-btn" data-tab="air">Air to Air</button>
-    <button class="tab-btn" data-tab="sead">SEAD</button>
-    <button class="tab-btn" data-tab="cas">CAS</button>
-    <button class="tab-btn" data-tab="strike">Strike</button>
-    <button class="tab-btn" data-tab="logistic">Logistic</button>
-    <button class="tab-btn" data-tab="csar">CSAR</button>
-    <button class="tab-btn" data-tab="recon">Recon</button>
+    <button class="tab-btn active" data-tab="general"><i class="fa-solid fa-star"></i> General</button>
+    <button class="tab-btn" data-tab="air"><i class="fa-solid fa-jet-fighter"></i> Air to Air</button>
+    <button class="tab-btn" data-tab="sead"><i class="fa-solid fa-explosion"></i> SEAD</button>
+    <button class="tab-btn" data-tab="cas"><i class="fa-solid fa-crosshairs"></i> CAS</button>
+    <button class="tab-btn" data-tab="strike"><i class="fa-solid fa-bomb"></i> Strike</button>
+    <button class="tab-btn" data-tab="logistic"><i class="fa-solid fa-truck"></i> Logistic</button>
+    <button class="tab-btn" data-tab="csar"><i class="fa-solid fa-helicopter"></i> CSAR</button>
+    <button class="tab-btn" data-tab="recon"><i class="fa-solid fa-binoculars"></i> Recon</button>
 </div>
-
-{% macro player_rows(sort_attr, cols) %}
-{% for player, stats in sitac.player_stats.items() | sort(attribute='1.' + sort_attr, reverse=True) %}
-<tr>
-    <td class="n">{{ loop.index }}</td>
-    <td>{{ player }}</td>
-    {% for col in cols %}{{ col(stats) }}{% endfor %}
-</tr>
-{% else %}
-<tr><td colspan="99" style="text-align: center; color: #5a6270;">No player data available</td></tr>
-{% endfor %}
-{% endmacro %}
 
 <!-- General -->
 <div class="tab-content active" data-tab-content="general">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
         <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Points Spent" data-sort-key="points_spent"><i class="fa-solid fa-coins"></i></th>
@@ -37,7 +25,7 @@
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
             <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.points_spent | int }}</td>
@@ -55,8 +43,9 @@
 <div class="tab-content" data-tab-content="air">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
         <th class="col-icon" data-tooltip="Helicopter Kills" data-sort-key="helo"><i class="fa-solid fa-helicopter"></i></th>
         <th class="col-icon" data-tooltip="Intercept Cargo Plane" data-sort-key="intercept"><i class="fa-solid fa-plane-circle-xmark"></i></th>
@@ -66,8 +55,9 @@
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.air', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
+            <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.air }}</td>
             <td class="n">{{ stats.helo }}</td>
             <td class="n">{{ stats.intercept_cargo_plane }}</td>
@@ -75,7 +65,7 @@
             <td class="n" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="7" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        <tr><td colspan="8" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>
@@ -85,19 +75,21 @@
 <div class="tab-content" data-tab-content="sead">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="SAM/Air Defense Kills" data-sort-key="sam"><i class="fa-solid fa-explosion"></i></th>
     </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.SAM', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
+            <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.SAM }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="3" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        <tr><td colspan="4" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>
@@ -107,8 +99,9 @@
 <div class="tab-content" data-tab-content="cas">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Ground Unit Kills" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
         <th class="col-icon" data-tooltip="Infantry Kills" data-sort-key="infantry"><i class="fa-solid fa-person-rifle"></i></th>
         <th class="col-icon" data-tooltip="CAS Missions" data-sort-key="cas_mission"><i class="fa-solid fa-bullseye"></i></th>
@@ -117,15 +110,16 @@
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.ground_units', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
+            <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.ground_units }}</td>
             <td class="n">{{ stats.infantry }}</td>
             <td class="n">{{ stats.CAS_mission }}</td>
             <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="6" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        <tr><td colspan="7" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>
@@ -135,21 +129,23 @@
 <div class="tab-content" data-tab-content="strike">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Structure Kills" data-sort-key="structure"><i class="fa-solid fa-building"></i></th>
         <th class="col-icon" data-tooltip="Bomb Runway" data-sort-key="bomb_runway"><i class="fa-solid fa-road"></i></th>
     </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.structure', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
+            <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.structure }}</td>
             <td class="n">{{ stats.bomb_runway }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="4" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        <tr><td colspan="5" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>
@@ -159,8 +155,9 @@
 <div class="tab-content" data-tab-content="logistic">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
         <th class="col-icon" data-tooltip="Warehouse Deliveries" data-sort-key="warehouse"><i class="fa-solid fa-warehouse"></i></th>
         <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
@@ -169,15 +166,16 @@
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.flight_time', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
+            <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.flight_time | int }}</td>
             <td class="n">{{ stats.warehouse_delivery }}</td>
             <td class="n">{{ stats.zone_capture }}</td>
             <td class="n">{{ stats.zone_upgrade }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="6" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        <tr><td colspan="7" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>
@@ -187,21 +185,23 @@
 <div class="tab-content" data-tab-content="csar">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
         <th class="col-icon" data-tooltip="Pilot Rescues" data-sort-key="pilot_rescue"><i class="fa-solid fa-parachute-box"></i></th>
     </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.pilot_rescue', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
+            <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.flight_time | int }}</td>
             <td class="n">{{ stats.pilot_rescue }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="4" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        <tr><td colspan="5" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>
@@ -211,19 +211,21 @@
 <div class="tab-content" data-tab-content="recon">
 <table class="modal-table players sortable">
     <thead><tr>
-        <th>#</th>
+        <th class="col-rank">#</th>
         <th data-sort-key="player" data-sort-type="string">Player</th>
+        <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Recon Missions" data-sort-key="recon"><i class="fa-solid fa-binoculars"></i></th>
     </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.recon_mission', reverse=True) %}
         <tr>
-            <td class="n">{{ loop.index }}</td>
+            <td class="n col-rank">{{ loop.index }}</td>
             <td>{{ player }}</td>
+            <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.recon_mission }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="3" style="text-align: center; color: #5a6270;">No player data available</td></tr>
+        <tr><td colspan="4" style="text-align: center; color: #5a6270;">No player data available</td></tr>
         {% endfor %}
     </tbody>
 </table>

--- a/src/foothold_sitac/templates/foothold/sitac.html
+++ b/src/foothold_sitac/templates/foothold/sitac.html
@@ -54,21 +54,21 @@
     <h2>Player Stats</h2>
 
     <div class="tabs ranking-tabs sitac-tabs">
-        <button class="tab-btn active" data-tab="general">General</button>
-        <button class="tab-btn" data-tab="air">Air to Air</button>
-        <button class="tab-btn" data-tab="sead">SEAD</button>
-        <button class="tab-btn" data-tab="cas">CAS</button>
-        <button class="tab-btn" data-tab="strike">Strike</button>
-        <button class="tab-btn" data-tab="logistic">Logistic</button>
-        <button class="tab-btn" data-tab="csar">CSAR</button>
-        <button class="tab-btn" data-tab="recon">Recon</button>
+        <button class="tab-btn active" data-tab="general"><i class="fa-solid fa-star"></i> General</button>
+        <button class="tab-btn" data-tab="air"><i class="fa-solid fa-jet-fighter"></i> Air to Air</button>
+        <button class="tab-btn" data-tab="sead"><i class="fa-solid fa-explosion"></i> SEAD</button>
+        <button class="tab-btn" data-tab="cas"><i class="fa-solid fa-crosshairs"></i> CAS</button>
+        <button class="tab-btn" data-tab="strike"><i class="fa-solid fa-bomb"></i> Strike</button>
+        <button class="tab-btn" data-tab="logistic"><i class="fa-solid fa-truck"></i> Logistic</button>
+        <button class="tab-btn" data-tab="csar"><i class="fa-solid fa-helicopter"></i> CSAR</button>
+        <button class="tab-btn" data-tab="recon"><i class="fa-solid fa-binoculars"></i> Recon</button>
     </div>
 
     <!-- General -->
     <div class="tab-content active" data-tab-content="general">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
             <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Points Spent" data-sort-key="points_spent"><i class="fa-solid fa-coins"></i></th>
@@ -78,7 +78,7 @@
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
                 <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.points_spent | int }}</td>
@@ -94,8 +94,9 @@
     <div class="tab-content" data-tab-content="air">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
             <th class="col-icon" data-tooltip="Helicopter Kills" data-sort-key="helo"><i class="fa-solid fa-helicopter"></i></th>
             <th class="col-icon" data-tooltip="Intercept Cargo Plane" data-sort-key="intercept"><i class="fa-solid fa-plane-circle-xmark"></i></th>
@@ -105,8 +106,9 @@
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.air', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
+                <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.air }}</td>
                 <td class="n">{{ stats.helo }}</td>
                 <td class="n">{{ stats.intercept_cargo_plane }}</td>
@@ -122,15 +124,17 @@
     <div class="tab-content" data-tab-content="sead">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="SAM/Air Defense Kills" data-sort-key="sam"><i class="fa-solid fa-explosion"></i></th>
         </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.SAM', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
+                <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.SAM }}</td>
             </tr>
             {% endfor %}
@@ -142,8 +146,9 @@
     <div class="tab-content" data-tab-content="cas">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Ground Unit Kills" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
             <th class="col-icon" data-tooltip="Infantry Kills" data-sort-key="infantry"><i class="fa-solid fa-person-rifle"></i></th>
             <th class="col-icon" data-tooltip="CAS Missions" data-sort-key="cas_mission"><i class="fa-solid fa-bullseye"></i></th>
@@ -152,8 +157,9 @@
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.ground_units', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
+                <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.ground_units }}</td>
                 <td class="n">{{ stats.infantry }}</td>
                 <td class="n">{{ stats.CAS_mission }}</td>
@@ -168,16 +174,18 @@
     <div class="tab-content" data-tab-content="strike">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Structure Kills" data-sort-key="structure"><i class="fa-solid fa-building"></i></th>
             <th class="col-icon" data-tooltip="Bomb Runway" data-sort-key="bomb_runway"><i class="fa-solid fa-road"></i></th>
         </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.structure', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
+                <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.structure }}</td>
                 <td class="n">{{ stats.bomb_runway }}</td>
             </tr>
@@ -190,8 +198,9 @@
     <div class="tab-content" data-tab-content="logistic">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
             <th class="col-icon" data-tooltip="Warehouse Deliveries" data-sort-key="warehouse"><i class="fa-solid fa-warehouse"></i></th>
             <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
@@ -200,8 +209,9 @@
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.flight_time', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
+                <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.flight_time | int }}</td>
                 <td class="n">{{ stats.warehouse_delivery }}</td>
                 <td class="n">{{ stats.zone_capture }}</td>
@@ -216,16 +226,18 @@
     <div class="tab-content" data-tab-content="csar">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
             <th class="col-icon" data-tooltip="Pilot Rescues" data-sort-key="pilot_rescue"><i class="fa-solid fa-parachute-box"></i></th>
         </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.pilot_rescue', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
+                <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.flight_time | int }}</td>
                 <td class="n">{{ stats.pilot_rescue }}</td>
             </tr>
@@ -238,15 +250,17 @@
     <div class="tab-content" data-tab-content="recon">
     <table class="sitac-table sortable">
         <thead><tr>
-            <th>#</th>
+            <th class="col-rank">#</th>
             <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Recon Missions" data-sort-key="recon"><i class="fa-solid fa-binoculars"></i></th>
         </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.recon_mission', reverse=True) %}
             <tr>
-                <td class="n">{{ loop.index }}</td>
+                <td class="n col-rank">{{ loop.index }}</td>
                 <td>{{ player }}</td>
+                <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.recon_mission }}</td>
             </tr>
             {% endfor %}

--- a/src/foothold_sitac/templates/foothold/sitac.html
+++ b/src/foothold_sitac/templates/foothold/sitac.html
@@ -52,40 +52,207 @@
 
     <!-- Section PLAYER STATS -->
     <h2>Player Stats</h2>
+
+    <div class="tabs ranking-tabs sitac-tabs">
+        <button class="tab-btn active" data-tab="general">General</button>
+        <button class="tab-btn" data-tab="air">Air to Air</button>
+        <button class="tab-btn" data-tab="sead">SEAD</button>
+        <button class="tab-btn" data-tab="cas">CAS</button>
+        <button class="tab-btn" data-tab="strike">Strike</button>
+        <button class="tab-btn" data-tab="logistic">Logistic</button>
+        <button class="tab-btn" data-tab="csar">CSAR</button>
+        <button class="tab-btn" data-tab="recon">Recon</button>
+    </div>
+
+    <!-- General -->
+    <div class="tab-content active" data-tab-content="general">
     <table class="sitac-table sortable">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th data-sort-key="player" data-sort-type="string">Player</th>
-                <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
-                <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
-                <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
-                <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
-                <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
-                <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
-                <th class="col-icon" data-tooltip="Air Kill/Death Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
-                <th class="col-icon" data-tooltip="Ground Kills (A/G)" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
-                <th class="col-icon" data-tooltip="Ground Kill/Death Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
-            </tr>
-        </thead>
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
+            <th class="col-icon" data-tooltip="Points Spent" data-sort-key="points_spent"><i class="fa-solid fa-coins"></i></th>
+            <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
+            <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
+        </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
             <tr>
                 <td class="n">{{ loop.index }}</td>
                 <td>{{ player }}</td>
-                <td class="n" data-tooltip="Points">{{ stats.points | int }}</td>
-                <td class="n" data-tooltip="Deaths">{{ stats.deaths }}</td>
-                <td class="n" data-tooltip="Points per Death" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
-                <td class="n" data-tooltip="Zone Captures">{{ stats.zone_capture }}</td>
-                <td class="n" data-tooltip="Zone Upgrades">{{ stats.zone_upgrade }}</td>
-                <td class="n" data-tooltip="Air Kills (A/A)">{{ stats.air }}</td>
-                <td class="n" data-tooltip="Air Kill/Death Ratio" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
-                <td class="n" data-tooltip="Ground Kills (A/G)">{{ stats.ground_units }}</td>
-                <td class="n" data-tooltip="Ground Kill/Death Ratio" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n">{{ stats.points | int }}</td>
+                <td class="n">{{ stats.points_spent | int }}</td>
+                <td class="n">{{ stats.deaths }}</td>
+                <td class="n" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
+    </div>
+
+    <!-- Air to Air -->
+    <div class="tab-content" data-tab-content="air">
+    <table class="sitac-table sortable">
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Air Kills (A/A)" data-sort-key="air"><i class="fa-solid fa-jet-fighter"></i></th>
+            <th class="col-icon" data-tooltip="Helicopter Kills" data-sort-key="helo"><i class="fa-solid fa-helicopter"></i></th>
+            <th class="col-icon" data-tooltip="Intercept Cargo Plane" data-sort-key="intercept"><i class="fa-solid fa-plane-circle-xmark"></i></th>
+            <th class="col-icon" data-tooltip="CAP Missions" data-sort-key="cap"><i class="fa-solid fa-shield-halved"></i></th>
+            <th class="col-icon" data-tooltip="Air K/D Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
+        </tr></thead>
+        <tbody>
+            {% for player, stats in sitac.player_stats.items() | sort(attribute='1.air', reverse=True) %}
+            <tr>
+                <td class="n">{{ loop.index }}</td>
+                <td>{{ player }}</td>
+                <td class="n">{{ stats.air }}</td>
+                <td class="n">{{ stats.helo }}</td>
+                <td class="n">{{ stats.intercept_cargo_plane }}</td>
+                <td class="n">{{ stats.CAP_mission }}</td>
+                <td class="n" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+
+    <!-- SEAD -->
+    <div class="tab-content" data-tab-content="sead">
+    <table class="sitac-table sortable">
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="SAM/Air Defense Kills" data-sort-key="sam"><i class="fa-solid fa-explosion"></i></th>
+        </tr></thead>
+        <tbody>
+            {% for player, stats in sitac.player_stats.items() | sort(attribute='1.SAM', reverse=True) %}
+            <tr>
+                <td class="n">{{ loop.index }}</td>
+                <td>{{ player }}</td>
+                <td class="n">{{ stats.SAM }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+
+    <!-- CAS -->
+    <div class="tab-content" data-tab-content="cas">
+    <table class="sitac-table sortable">
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Ground Unit Kills" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
+            <th class="col-icon" data-tooltip="Infantry Kills" data-sort-key="infantry"><i class="fa-solid fa-person-rifle"></i></th>
+            <th class="col-icon" data-tooltip="CAS Missions" data-sort-key="cas_mission"><i class="fa-solid fa-bullseye"></i></th>
+            <th class="col-icon" data-tooltip="Ground K/D Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
+        </tr></thead>
+        <tbody>
+            {% for player, stats in sitac.player_stats.items() | sort(attribute='1.ground_units', reverse=True) %}
+            <tr>
+                <td class="n">{{ loop.index }}</td>
+                <td>{{ player }}</td>
+                <td class="n">{{ stats.ground_units }}</td>
+                <td class="n">{{ stats.infantry }}</td>
+                <td class="n">{{ stats.CAS_mission }}</td>
+                <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+
+    <!-- Strike -->
+    <div class="tab-content" data-tab-content="strike">
+    <table class="sitac-table sortable">
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Structure Kills" data-sort-key="structure"><i class="fa-solid fa-building"></i></th>
+            <th class="col-icon" data-tooltip="Bomb Runway" data-sort-key="bomb_runway"><i class="fa-solid fa-road"></i></th>
+        </tr></thead>
+        <tbody>
+            {% for player, stats in sitac.player_stats.items() | sort(attribute='1.structure', reverse=True) %}
+            <tr>
+                <td class="n">{{ loop.index }}</td>
+                <td>{{ player }}</td>
+                <td class="n">{{ stats.structure }}</td>
+                <td class="n">{{ stats.bomb_runway }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+
+    <!-- Logistic -->
+    <div class="tab-content" data-tab-content="logistic">
+    <table class="sitac-table sortable">
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
+            <th class="col-icon" data-tooltip="Warehouse Deliveries" data-sort-key="warehouse"><i class="fa-solid fa-warehouse"></i></th>
+            <th class="col-icon" data-tooltip="Zone Captures" data-sort-key="zone_capture"><i class="fa-solid fa-flag"></i></th>
+            <th class="col-icon" data-tooltip="Zone Upgrades" data-sort-key="zone_upgrade"><i class="fa-solid fa-arrow-up"></i></th>
+        </tr></thead>
+        <tbody>
+            {% for player, stats in sitac.player_stats.items() | sort(attribute='1.flight_time', reverse=True) %}
+            <tr>
+                <td class="n">{{ loop.index }}</td>
+                <td>{{ player }}</td>
+                <td class="n">{{ stats.flight_time | int }}</td>
+                <td class="n">{{ stats.warehouse_delivery }}</td>
+                <td class="n">{{ stats.zone_capture }}</td>
+                <td class="n">{{ stats.zone_upgrade }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+
+    <!-- CSAR -->
+    <div class="tab-content" data-tab-content="csar">
+    <table class="sitac-table sortable">
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Flight Time (min)" data-sort-key="flight_time"><i class="fa-solid fa-clock"></i></th>
+            <th class="col-icon" data-tooltip="Pilot Rescues" data-sort-key="pilot_rescue"><i class="fa-solid fa-parachute-box"></i></th>
+        </tr></thead>
+        <tbody>
+            {% for player, stats in sitac.player_stats.items() | sort(attribute='1.pilot_rescue', reverse=True) %}
+            <tr>
+                <td class="n">{{ loop.index }}</td>
+                <td>{{ player }}</td>
+                <td class="n">{{ stats.flight_time | int }}</td>
+                <td class="n">{{ stats.pilot_rescue }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+
+    <!-- Recon -->
+    <div class="tab-content" data-tab-content="recon">
+    <table class="sitac-table sortable">
+        <thead><tr>
+            <th>#</th>
+            <th data-sort-key="player" data-sort-type="string">Player</th>
+            <th class="col-icon" data-tooltip="Recon Missions" data-sort-key="recon"><i class="fa-solid fa-binoculars"></i></th>
+        </tr></thead>
+        <tbody>
+            {% for player, stats in sitac.player_stats.items() | sort(attribute='1.recon_mission', reverse=True) %}
+            <tr>
+                <td class="n">{{ loop.index }}</td>
+                <td>{{ player }}</td>
+                <td class="n">{{ stats.recon_mission }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
 
     <div style="text-align:center;">
         <a href="{{ request.url_for('foothold_servers') }}" class="sitac-back-btn">Back to servers list</a>
@@ -97,6 +264,22 @@
 <script src="{{ static_url('js/tooltips.js') }}"></script>
 <script src="{{ static_url('js/table-sort.js') }}"></script>
 <script>
-    document.querySelectorAll('.sitac-table.sortable').forEach(initTableSort);
+    // Init sort on the default active table
+    document.querySelectorAll('.tab-content.active .sitac-table.sortable').forEach(initTableSort);
+
+    // Tab switching
+    document.querySelectorAll('.ranking-tabs .tab-btn').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var tab = btn.getAttribute('data-tab');
+            var container = btn.closest('.sitac-container');
+            container.querySelectorAll('.ranking-tabs .tab-btn').forEach(function(b) { b.classList.remove('active'); });
+            btn.classList.add('active');
+            container.querySelectorAll('.tab-content').forEach(function(c) {
+                c.classList.toggle('active', c.getAttribute('data-tab-content') === tab);
+            });
+            var activeTable = container.querySelector('.tab-content.active .sitac-table.sortable');
+            if (activeTable) initTableSort(activeTable);
+        });
+    });
 </script>
 {% endblock %}


### PR DESCRIPTION

<img width="1001" height="465" alt="image" src="https://github.com/user-attachments/assets/d3edb92a-9ae3-4e78-ad6a-0103f9db93e5" />


## Summary by Sourcery

Add categorized player ranking tabs and expose additional player metrics across the SITAC page and player rankings modal.

New Features:
- Introduce tabbed player rankings separating metrics into General, Air to Air, SEAD, CAS, Strike, Logistic, CSAR, and Recon categories.
- Display new player statistics such as structures destroyed, CAP and CAS missions, recon missions, pilot rescues, flight time, warehouse deliveries, runway bombings, and cargo plane interceptions in the UI.

Enhancements:
- Refine general player ranking views to show points spent and normalize points-per-death while keeping sortable behavior per tab.
- Standardize rank column widths and styling for player tables in both the SITAC page and modal, and slightly widen the SITAC layout for better table fit.

Documentation:
- Document the new player metrics and tabbed ranking layout in the changelog.