### PR TITLE
Fix zone upgrade display showing wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix zone upgrade display showing wrong value (`upgradesUsed` always 0), now displays zone level instead ([#120](https://github.com/VEAF/foothold-sitac/issues/120))
+
+
 ## [0.3.0] - 2026-03-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- Fix zone upgrade display showing wrong value (`upgradesUsed` always 0), now displays zone level instead ([#120](https://github.com/VEAF/foothold-sitac/issues/120))
+- Fix zone upgrade display showing the wrong value (`upgradesUsed` always 0), now displays zone level instead ([#120](https://github.com/VEAF/foothold-sitac/issues/120))
 
 
 ## [0.3.0] - 2026-03-13

--- a/src/foothold_sitac/static/js/map.js
+++ b/src/foothold_sitac/static/js/map.js
@@ -147,8 +147,8 @@ function openZoneModal(zone) {
                 '<td style="padding: 8px 0; text-align: right; color: #e8eaed;">' + zone.units + '</td>' +
             '</tr>' +
             '<tr>' +
-                '<td style="padding: 8px 0; color: #8892a0;">Upgrades</td>' +
-                '<td style="padding: 8px 0; text-align: right; color: #e8eaed;">' + (zone.upgrades_used || 0) + ' / ' + zone.level + '</td>' +
+                '<td style="padding: 8px 0; color: #8892a0;">Level</td>' +
+                '<td style="padding: 8px 0; text-align: right; color: #e8eaed;">' + zone.level + '</td>' +
             '</tr>' +
             '<tr>' +
                 '<td style="padding: 8px 0; color: #8892a0;">Lat / Lon</td>' +

--- a/src/foothold_sitac/static/js/map.js
+++ b/src/foothold_sitac/static/js/map.js
@@ -148,7 +148,7 @@ function openZoneModal(zone) {
             '</tr>' +
             '<tr>' +
                 '<td style="padding: 8px 0; color: #8892a0;">Level</td>' +
-                '<td style="padding: 8px 0; text-align: right; color: #e8eaed;">' + zone.level + '</td>' +
+                '<td style="padding: 8px 0; text-align: right; color: #e8eaed;">' + (zone.level != null ? zone.level : '-') + '</td>' +
             '</tr>' +
             '<tr>' +
                 '<td style="padding: 8px 0; color: #8892a0;">Lat / Lon</td>' +

--- a/src/foothold_sitac/templates/foothold/partials/zones.html
+++ b/src/foothold_sitac/templates/foothold/partials/zones.html
@@ -47,7 +47,6 @@
             <tr>
                 <th>Name</th>
                 <th>Level</th>
-                <th>Upgrades Used</th>
                 <th>Active</th>
             </tr>
         </thead>
@@ -56,7 +55,6 @@
             <tr>
                 <td>{{ name }}</td>
                 <td class="n">{{ zone.level }}</td>
-                <td class="n">{{ zone.upgradesUsed }}</td>
                 <td>{{ 'Yes' if zone.active else 'No' }}</td>
             </tr>
             {% endfor %}
@@ -74,7 +72,6 @@
             <tr>
                 <th>Name</th>
                 <th>Level</th>
-                <th>Upgrades Used</th>
                 <th>Active</th>
             </tr>
         </thead>
@@ -83,7 +80,6 @@
             <tr>
                 <td>{{ name }}</td>
                 <td class="n">{{ zone.level }}</td>
-                <td class="n">{{ zone.upgradesUsed }}</td>
                 <td>{{ 'Yes' if zone.active else 'No' }}</td>
             </tr>
             {% endfor %}
@@ -101,7 +97,6 @@
             <tr>
                 <th>Name</th>
                 <th>Level</th>
-                <th>Upgrades Used</th>
                 <th>Active</th>
             </tr>
         </thead>
@@ -110,7 +105,6 @@
             <tr>
                 <td>{{ name }}</td>
                 <td class="n">{{ zone.level }}</td>
-                <td class="n">{{ zone.upgradesUsed }}</td>
                 <td>{{ 'Yes' if zone.active else 'No' }}</td>
             </tr>
             {% endfor %}

--- a/src/foothold_sitac/templates/foothold/partials/zones.html
+++ b/src/foothold_sitac/templates/foothold/partials/zones.html
@@ -1,3 +1,28 @@
+{% macro zones_table(zones, empty_label) %}
+    {% if zones %}
+    <table class="modal-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Level</th>
+                <th>Active</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for name, zone in zones %}
+            <tr>
+                <td>{{ name }}</td>
+                <td class="n">{{ zone.level }}</td>
+                <td>{{ 'Yes' if zone.active else 'No' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <div class="empty-state">{{ empty_label }}</div>
+    {% endif %}
+{% endmacro %}
+
 {% set blue_zones = [] %}
 {% set neutral_zones = [] %}
 {% set red_zones = [] %}
@@ -41,78 +66,15 @@
 
     <div class="tab-content-wrapper">
         <div id="tab-blue" class="tab-content active">
-    {% if blue_zones %}
-    <table class="modal-table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Level</th>
-                <th>Active</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for name, zone in blue_zones %}
-            <tr>
-                <td>{{ name }}</td>
-                <td class="n">{{ zone.level }}</td>
-                <td>{{ 'Yes' if zone.active else 'No' }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    {% else %}
-    <div class="empty-state">No blue zones</div>
-    {% endif %}
-</div>
+            {{ zones_table(blue_zones, "No blue zones") }}
+        </div>
 
-<div id="tab-neutral" class="tab-content">
-    {% if neutral_zones %}
-    <table class="modal-table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Level</th>
-                <th>Active</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for name, zone in neutral_zones %}
-            <tr>
-                <td>{{ name }}</td>
-                <td class="n">{{ zone.level }}</td>
-                <td>{{ 'Yes' if zone.active else 'No' }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    {% else %}
-    <div class="empty-state">No neutral zones</div>
-    {% endif %}
-</div>
+        <div id="tab-neutral" class="tab-content">
+            {{ zones_table(neutral_zones, "No neutral zones") }}
+        </div>
 
-<div id="tab-red" class="tab-content">
-    {% if red_zones %}
-    <table class="modal-table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Level</th>
-                <th>Active</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for name, zone in red_zones %}
-            <tr>
-                <td>{{ name }}</td>
-                <td class="n">{{ zone.level }}</td>
-                <td>{{ 'Yes' if zone.active else 'No' }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    {% else %}
-    <div class="empty-state">No red zones</div>
-    {% endif %}
+        <div id="tab-red" class="tab-content">
+            {{ zones_table(red_zones, "No red zones") }}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary by Sourcery

Update zone UI to consistently display zone level instead of an incorrect upgrades-used value.

Bug Fixes:
- Correct zone detail modal to show zone level rather than an always-zero upgrades-used value.
- Remove misleading Upgrades Used column from zone tables to prevent displaying incorrect upgrade data.

Documentation:
- Document the zone upgrade display fix in the changelog under the Unreleased section.