### PR TITLE
parse weather info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `WeatherInfo` model to parse weather data from Lua persistence files with float support for `wind_direction` ([#122](https://github.com/VEAF/foothold-sitac/issues/122))
+
 ### Fixed
 
 - Fix zone upgrade display showing the wrong value (`upgradesUsed` always 0), now displays zone level instead ([#120](https://github.com/VEAF/foothold-sitac/issues/120))

--- a/src/foothold_sitac/foothold.py
+++ b/src/foothold_sitac/foothold.py
@@ -131,6 +131,16 @@ class Accounts(BaseModel):
     blue: float = 0
 
 
+class WeatherInfo(BaseModel):
+    wind_direction: float = Field(alias="windDirection", default=0)
+    wind_speed: float = Field(alias="windSpeed", default=0)
+    temperature: float = Field(alias="temperature", default=0)
+    pressure: float = Field(alias="pressure", default=0)
+    cloud_base: float = Field(alias="cloudBase", default=0)
+    cloud_density: int = Field(alias="cloudDensity", default=0)
+    fog_visibility: float = Field(alias="fogVisibility", default=0)
+
+
 class Sitac(BaseModel):
     updated_at: datetime
     zones: dict[str, Zone]
@@ -140,6 +150,7 @@ class Sitac(BaseModel):
     players: list[Player] = Field(default_factory=list)
     ejected_pilots: list[EjectedPilot] = Field(alias="ejectedPilots", default_factory=list)
     accounts: Accounts = Field(default_factory=Accounts)
+    weather_info: WeatherInfo | None = Field(alias="weatherInfo", default=None)
 
     @field_validator("accounts", mode="before")
     @classmethod

--- a/tests/fixtures/test_weather/Missions/Saves/foothold_weather.lua
+++ b/tests/fixtures/test_weather/Missions/Saves/foothold_weather.lua
@@ -1,0 +1,4 @@
+zonePersistance = {}
+zonePersistance['zones'] = { ['Zone1']={ ['upgradesUsed']=0,['side']=1,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['firstCaptureByRed']=true,['level']=1,['wasBlue']=false,['lat_long']={ ['longitude']=54.0,['latitude']=26.0,['altitude']=0 },['triggers']={ ['missioncompleted']=0 } } }
+zonePersistance['playerStats'] = { }
+zonePersistance['weatherInfo'] = { ['windDirection']=240.99997522634,['windSpeed']=5.5,['temperature']=20.3,['pressure']=760.0,['cloudBase']=3000.0,['cloudDensity']=5,['fogVisibility']=10000.0 }

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from foothold_sitac.foothold import Connection, EjectedPilot, Mission, Player, Zone, load_sitac
+from foothold_sitac.foothold import Connection, EjectedPilot, Mission, Player, WeatherInfo, Zone, load_sitac
 
 
 @pytest.fixture
@@ -460,3 +460,63 @@ def test_load_sitac_without_accounts() -> None:
 
     assert sitac.accounts.red == 0
     assert sitac.accounts.blue == 0
+
+
+# WeatherInfo tests
+
+
+def test_weather_info_model_validation() -> None:
+    """Test WeatherInfo accepts float wind_direction (issue #122)"""
+    weather_data = {
+        "windDirection": 240.99997522634,
+        "windSpeed": 5.5,
+        "temperature": 20.3,
+        "pressure": 760.0,
+        "cloudBase": 3000.0,
+        "cloudDensity": 5,
+        "fogVisibility": 10000.0,
+    }
+    weather = WeatherInfo.model_validate(weather_data)
+    assert weather.wind_direction == 240.99997522634
+    assert weather.wind_speed == 5.5
+    assert weather.temperature == 20.3
+    assert weather.pressure == 760.0
+    assert weather.cloud_base == 3000.0
+    assert weather.cloud_density == 5
+    assert weather.fog_visibility == 10000.0
+
+
+def test_weather_info_model_defaults() -> None:
+    """Test WeatherInfo defaults when no data provided"""
+    weather = WeatherInfo.model_validate({})
+    assert weather.wind_direction == 0
+    assert weather.wind_speed == 0
+    assert weather.temperature == 0
+    assert weather.pressure == 0
+
+
+def test_weather_info_accepts_integers() -> None:
+    """Test WeatherInfo accepts integer values for float fields"""
+    weather_data = {"windDirection": 240, "windSpeed": 5}
+    weather = WeatherInfo.model_validate(weather_data)
+    assert weather.wind_direction == 240.0
+    assert weather.wind_speed == 5.0
+
+
+def test_load_sitac_with_weather_info() -> None:
+    """Test loading sitac with weatherInfo from Lua"""
+    lua_path = Path("tests/fixtures/test_weather/Missions/Saves/foothold_weather.lua")
+    sitac = load_sitac(lua_path)
+
+    assert sitac.weather_info is not None
+    assert sitac.weather_info.wind_direction == 240.99997522634
+    assert sitac.weather_info.wind_speed == 5.5
+    assert sitac.weather_info.temperature == 20.3
+
+
+def test_load_sitac_without_weather_info() -> None:
+    """Test loading sitac without weatherInfo section (backward compatibility)"""
+    lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+    sitac = load_sitac(lua_path)
+
+    assert sitac.weather_info is None


### PR DESCRIPTION
## Summary by Sourcery

Add structured weather information parsing and exposure in Sitac, with support for float values and backward compatibility when no weather data is present.

New Features:
- Introduce a WeatherInfo model to represent weather data loaded from Lua persistence files and associate it with Sitac.

Documentation:
- Document the new WeatherInfo support in the changelog.

Tests:
- Add unit tests for WeatherInfo model validation, default values, integer-to-float coercion, and Sitac loading with and without weatherInfo data.
- Add Lua fixture for missions including persisted weatherInfo data.