### PR TITLE
Use per life ratios instead of per death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Add `WeatherInfo` model to parse weather data from Lua persistence files with float support for `wind_direction` ([#122](https://github.com/VEAF/foothold-sitac/issues/122))
 
+### Changed
+
+- Use "per life" ratios instead of "per death" (Points/Life, Air K/L, Ground K/L) so ratios are always calculable, even with 0 deaths ([#119](https://github.com/VEAF/foothold-sitac/issues/119))
+
 ### Fixed
 
 - Fix zone upgrade display showing the wrong value (`upgradesUsed` always 0), now displays zone level instead ([#120](https://github.com/VEAF/foothold-sitac/issues/120))

--- a/src/foothold_sitac/foothold.py
+++ b/src/foothold_sitac/foothold.py
@@ -125,6 +125,10 @@ class PlayerStats(BaseModel):
     bomb_runway: int = Field(alias="Bomb runway", default=0)
     intercept_cargo_plane: int = Field(alias="Intercept cargo plane", default=0)
 
+    @property
+    def lives(self) -> int:
+        return self.deaths + 1
+
 
 class Accounts(BaseModel):
     red: float = 0

--- a/src/foothold_sitac/templates/foothold/partials/players.html
+++ b/src/foothold_sitac/templates/foothold/partials/players.html
@@ -30,7 +30,7 @@
             <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.points_spent | int }}</td>
             <td class="n">{{ stats.deaths }}</td>
-            <td class="n" data-sort-value="{{ (stats.points / (stats.deaths + 1)) | round(1) }}">{{ (stats.points / (stats.deaths + 1)) | round(1) }}</td>
+            <td class="n" data-sort-value="{{ (stats.points / stats.lives) | round(1) }}">{{ (stats.points / stats.lives) | round(1) }}</td>
         </tr>
         {% else %}
         <tr><td colspan="6" style="text-align: center; color: #5a6270;">No player data available</td></tr>
@@ -62,7 +62,7 @@
             <td class="n">{{ stats.helo }}</td>
             <td class="n">{{ stats.intercept_cargo_plane }}</td>
             <td class="n">{{ stats.CAP_mission }}</td>
-            <td class="n" data-sort-value="{{ (stats.air / (stats.deaths + 1)) | round(1) }}">{{ (stats.air / (stats.deaths + 1)) | round(1) }}</td>
+            <td class="n" data-sort-value="{{ (stats.air / stats.lives) | round(1) }}">{{ (stats.air / stats.lives) | round(1) }}</td>
         </tr>
         {% else %}
         <tr><td colspan="8" style="text-align: center; color: #5a6270;">No player data available</td></tr>
@@ -116,7 +116,7 @@
             <td class="n">{{ stats.ground_units }}</td>
             <td class="n">{{ stats.infantry }}</td>
             <td class="n">{{ stats.CAS_mission }}</td>
-            <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}">{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}</td>
+            <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.lives) | round(1) }}">{{ ((stats.ground_units + stats.infantry) / stats.lives) | round(1) }}</td>
         </tr>
         {% else %}
         <tr><td colspan="7" style="text-align: center; color: #5a6270;">No player data available</td></tr>

--- a/src/foothold_sitac/templates/foothold/partials/players.html
+++ b/src/foothold_sitac/templates/foothold/partials/players.html
@@ -20,7 +20,7 @@
         <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
         <th class="col-icon" data-tooltip="Points Spent" data-sort-key="points_spent"><i class="fa-solid fa-coins"></i></th>
         <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
-        <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
+        <th class="col-icon" data-tooltip="Points per Life" data-sort-key="points_per_life"><i class="fa-solid fa-chart-line"></i></th>
     </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
@@ -30,7 +30,7 @@
             <td class="n">{{ stats.points | int }}</td>
             <td class="n">{{ stats.points_spent | int }}</td>
             <td class="n">{{ stats.deaths }}</td>
-            <td class="n" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-sort-value="{{ (stats.points / (stats.deaths + 1)) | round(1) }}">{{ (stats.points / (stats.deaths + 1)) | round(1) }}</td>
         </tr>
         {% else %}
         <tr><td colspan="6" style="text-align: center; color: #5a6270;">No player data available</td></tr>
@@ -50,7 +50,7 @@
         <th class="col-icon" data-tooltip="Helicopter Kills" data-sort-key="helo"><i class="fa-solid fa-helicopter"></i></th>
         <th class="col-icon" data-tooltip="Intercept Cargo Plane" data-sort-key="intercept"><i class="fa-solid fa-plane-circle-xmark"></i></th>
         <th class="col-icon" data-tooltip="CAP Missions" data-sort-key="cap"><i class="fa-solid fa-shield-halved"></i></th>
-        <th class="col-icon" data-tooltip="Air K/D Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
+        <th class="col-icon" data-tooltip="Air K/L Ratio" data-sort-key="air_kl"><i class="fa-solid fa-percent"></i></th>
     </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.air', reverse=True) %}
@@ -62,7 +62,7 @@
             <td class="n">{{ stats.helo }}</td>
             <td class="n">{{ stats.intercept_cargo_plane }}</td>
             <td class="n">{{ stats.CAP_mission }}</td>
-            <td class="n" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-sort-value="{{ (stats.air / (stats.deaths + 1)) | round(1) }}">{{ (stats.air / (stats.deaths + 1)) | round(1) }}</td>
         </tr>
         {% else %}
         <tr><td colspan="8" style="text-align: center; color: #5a6270;">No player data available</td></tr>
@@ -105,7 +105,7 @@
         <th class="col-icon" data-tooltip="Ground Unit Kills" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
         <th class="col-icon" data-tooltip="Infantry Kills" data-sort-key="infantry"><i class="fa-solid fa-person-rifle"></i></th>
         <th class="col-icon" data-tooltip="CAS Missions" data-sort-key="cas_mission"><i class="fa-solid fa-bullseye"></i></th>
-        <th class="col-icon" data-tooltip="Ground K/D Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
+        <th class="col-icon" data-tooltip="Ground K/L Ratio" data-sort-key="ground_kl"><i class="fa-solid fa-percent"></i></th>
     </tr></thead>
     <tbody>
         {% for player, stats in sitac.player_stats.items() | sort(attribute='1.ground_units', reverse=True) %}
@@ -116,7 +116,7 @@
             <td class="n">{{ stats.ground_units }}</td>
             <td class="n">{{ stats.infantry }}</td>
             <td class="n">{{ stats.CAS_mission }}</td>
-            <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+            <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}">{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}</td>
         </tr>
         {% else %}
         <tr><td colspan="7" style="text-align: center; color: #5a6270;">No player data available</td></tr>

--- a/src/foothold_sitac/templates/foothold/player.html
+++ b/src/foothold_sitac/templates/foothold/player.html
@@ -33,7 +33,7 @@
             <span class="stat-label">Deaths</span>
         </div>
         <div class="stat-card">
-            <span class="stat-value">{{ (stats.points / (stats.deaths + 1)) | round(1) }}</span>
+            <span class="stat-value">{{ (stats.points / stats.lives) | round(1) }}</span>
             <span class="stat-label">Points / Life</span>
         </div>
         <div class="stat-card">
@@ -68,7 +68,7 @@
             <div class="stat-item">
                 <i class="fa-solid fa-percent"></i>
                 <span class="stat-item-label">Air K/L</span>
-                <span class="stat-item-value">{{ (stats.air / (stats.deaths + 1)) | round(1) }}</span>
+                <span class="stat-item-value">{{ (stats.air / stats.lives) | round(1) }}</span>
             </div>
         </div>
     </div>
@@ -109,7 +109,7 @@
             <div class="stat-item">
                 <i class="fa-solid fa-percent"></i>
                 <span class="stat-item-label">Ground K/L</span>
-                <span class="stat-item-value">{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}</span>
+                <span class="stat-item-value">{{ ((stats.ground_units + stats.infantry) / stats.lives) | round(1) }}</span>
             </div>
         </div>
     </div>

--- a/src/foothold_sitac/templates/foothold/player.html
+++ b/src/foothold_sitac/templates/foothold/player.html
@@ -33,8 +33,8 @@
             <span class="stat-label">Deaths</span>
         </div>
         <div class="stat-card">
-            <span class="stat-value">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</span>
-            <span class="stat-label">Points / Death</span>
+            <span class="stat-value">{{ (stats.points / (stats.deaths + 1)) | round(1) }}</span>
+            <span class="stat-label">Points / Life</span>
         </div>
         <div class="stat-card">
             <span class="stat-value">{{ stats.flight_time | int }}</span>
@@ -67,8 +67,8 @@
             </div>
             <div class="stat-item">
                 <i class="fa-solid fa-percent"></i>
-                <span class="stat-item-label">Air K/D</span>
-                <span class="stat-item-value">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</span>
+                <span class="stat-item-label">Air K/L</span>
+                <span class="stat-item-value">{{ (stats.air / (stats.deaths + 1)) | round(1) }}</span>
             </div>
         </div>
     </div>
@@ -108,8 +108,8 @@
             </div>
             <div class="stat-item">
                 <i class="fa-solid fa-percent"></i>
-                <span class="stat-item-label">Ground K/D</span>
-                <span class="stat-item-value">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</span>
+                <span class="stat-item-label">Ground K/L</span>
+                <span class="stat-item-value">{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}</span>
             </div>
         </div>
     </div>

--- a/src/foothold_sitac/templates/foothold/sitac.html
+++ b/src/foothold_sitac/templates/foothold/sitac.html
@@ -83,7 +83,7 @@
                 <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.points_spent | int }}</td>
                 <td class="n">{{ stats.deaths }}</td>
-                <td class="n" data-sort-value="{{ (stats.points / (stats.deaths + 1)) | round(1) }}">{{ (stats.points / (stats.deaths + 1)) | round(1) }}</td>
+                <td class="n" data-sort-value="{{ (stats.points / stats.lives) | round(1) }}">{{ (stats.points / stats.lives) | round(1) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -113,7 +113,7 @@
                 <td class="n">{{ stats.helo }}</td>
                 <td class="n">{{ stats.intercept_cargo_plane }}</td>
                 <td class="n">{{ stats.CAP_mission }}</td>
-                <td class="n" data-sort-value="{{ (stats.air / (stats.deaths + 1)) | round(1) }}">{{ (stats.air / (stats.deaths + 1)) | round(1) }}</td>
+                <td class="n" data-sort-value="{{ (stats.air / stats.lives) | round(1) }}">{{ (stats.air / stats.lives) | round(1) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -163,7 +163,7 @@
                 <td class="n">{{ stats.ground_units }}</td>
                 <td class="n">{{ stats.infantry }}</td>
                 <td class="n">{{ stats.CAS_mission }}</td>
-                <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}">{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}</td>
+                <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.lives) | round(1) }}">{{ ((stats.ground_units + stats.infantry) / stats.lives) | round(1) }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/src/foothold_sitac/templates/foothold/sitac.html
+++ b/src/foothold_sitac/templates/foothold/sitac.html
@@ -73,7 +73,7 @@
             <th class="col-icon" data-tooltip="Points" data-sort-key="points"><i class="fa-solid fa-star"></i></th>
             <th class="col-icon" data-tooltip="Points Spent" data-sort-key="points_spent"><i class="fa-solid fa-coins"></i></th>
             <th class="col-icon" data-tooltip="Deaths" data-sort-key="deaths"><i class="fa-solid fa-skull"></i></th>
-            <th class="col-icon" data-tooltip="Points per Death" data-sort-key="points_per_death"><i class="fa-solid fa-chart-line"></i></th>
+            <th class="col-icon" data-tooltip="Points per Life" data-sort-key="points_per_life"><i class="fa-solid fa-chart-line"></i></th>
         </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.points', reverse=True) %}
@@ -83,7 +83,7 @@
                 <td class="n">{{ stats.points | int }}</td>
                 <td class="n">{{ stats.points_spent | int }}</td>
                 <td class="n">{{ stats.deaths }}</td>
-                <td class="n" data-sort-value="{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.points / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-sort-value="{{ (stats.points / (stats.deaths + 1)) | round(1) }}">{{ (stats.points / (stats.deaths + 1)) | round(1) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -101,7 +101,7 @@
             <th class="col-icon" data-tooltip="Helicopter Kills" data-sort-key="helo"><i class="fa-solid fa-helicopter"></i></th>
             <th class="col-icon" data-tooltip="Intercept Cargo Plane" data-sort-key="intercept"><i class="fa-solid fa-plane-circle-xmark"></i></th>
             <th class="col-icon" data-tooltip="CAP Missions" data-sort-key="cap"><i class="fa-solid fa-shield-halved"></i></th>
-            <th class="col-icon" data-tooltip="Air K/D Ratio" data-sort-key="air_kd"><i class="fa-solid fa-percent"></i></th>
+            <th class="col-icon" data-tooltip="Air K/L Ratio" data-sort-key="air_kl"><i class="fa-solid fa-percent"></i></th>
         </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.air', reverse=True) %}
@@ -113,7 +113,7 @@
                 <td class="n">{{ stats.helo }}</td>
                 <td class="n">{{ stats.intercept_cargo_plane }}</td>
                 <td class="n">{{ stats.CAP_mission }}</td>
-                <td class="n" data-sort-value="{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ (stats.air / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-sort-value="{{ (stats.air / (stats.deaths + 1)) | round(1) }}">{{ (stats.air / (stats.deaths + 1)) | round(1) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -152,7 +152,7 @@
             <th class="col-icon" data-tooltip="Ground Unit Kills" data-sort-key="ground_units"><i class="fa-solid fa-crosshairs"></i></th>
             <th class="col-icon" data-tooltip="Infantry Kills" data-sort-key="infantry"><i class="fa-solid fa-person-rifle"></i></th>
             <th class="col-icon" data-tooltip="CAS Missions" data-sort-key="cas_mission"><i class="fa-solid fa-bullseye"></i></th>
-            <th class="col-icon" data-tooltip="Ground K/D Ratio" data-sort-key="ground_kd"><i class="fa-solid fa-percent"></i></th>
+            <th class="col-icon" data-tooltip="Ground K/L Ratio" data-sort-key="ground_kl"><i class="fa-solid fa-percent"></i></th>
         </tr></thead>
         <tbody>
             {% for player, stats in sitac.player_stats.items() | sort(attribute='1.ground_units', reverse=True) %}
@@ -163,7 +163,7 @@
                 <td class="n">{{ stats.ground_units }}</td>
                 <td class="n">{{ stats.infantry }}</td>
                 <td class="n">{{ stats.CAS_mission }}</td>
-                <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '' }}">{{ ((stats.ground_units + stats.infantry) / stats.deaths) | round(1) if stats.deaths > 0 else '-' }}</td>
+                <td class="n" data-sort-value="{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}">{{ ((stats.ground_units + stats.infantry) / (stats.deaths + 1)) | round(1) }}</td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary by Sourcery

Update player statistics to use per-life ratios instead of per-death ratios across the UI so metrics remain defined even when a player has zero deaths.

Enhancements:
- Replace points, air, and ground performance metrics to be calculated per life (deaths + 1) rather than per death in player and SITAC views.
- Rename related labels, tooltips, and sort keys from K/D and Points per Death to K/L and Points per Life for consistency with the new calculation logic.

Documentation:
- Document the switch from per-death to per-life ratios in the changelog, including affected metrics and rationale.