### PR TITLE
Display missions with coordinates as target markers on the map*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - Add `WeatherInfo` model to parse weather data from Lua persistence files with float support for `wind_direction` ([#122](https://github.com/VEAF/foothold-sitac/issues/122))
+- Display missions with coordinates as target markers on the map ([#121](https://github.com/VEAF/foothold-sitac/issues/121))
 
 ### Changed
 

--- a/src/foothold_sitac/foothold.py
+++ b/src/foothold_sitac/foothold.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -195,6 +196,53 @@ class Sitac(BaseModel):
         if total_contested == 0:
             return 0.0
         return blue_zones / total_contested * 100
+
+
+def _parse_dms(text: str) -> Position | None:
+    regex = r"([NS])\s*(\d+)[°]\s*(\d+)[''′]\s*([\d.]+)[\"\"″]?\s*([EW])\s*(\d+)[°]\s*(\d+)[''′]\s*([\d.]+)[\"\"″]?"
+    match = re.search(regex, text, re.IGNORECASE)
+    if not match:
+        return None
+    lat = float(match.group(2)) + float(match.group(3)) / 60 + float(match.group(4)) / 3600
+    if match.group(1).upper() == "S":
+        lat = -lat
+    lon = float(match.group(6)) + float(match.group(7)) / 60 + float(match.group(8)) / 3600
+    if match.group(5).upper() == "W":
+        lon = -lon
+    return Position(latitude=lat, longitude=lon)
+
+
+def _parse_ddm(text: str) -> Position | None:
+    regex = r"([NS])\s*(\d+)[°]\s*(\d+\.\d+)[''′]\s*([EW])\s*(\d+)[°]\s*(\d+\.\d+)[''′]"
+    match = re.search(regex, text, re.IGNORECASE)
+    if not match:
+        return None
+    lat = float(match.group(2)) + float(match.group(3)) / 60
+    if match.group(1).upper() == "S":
+        lat = -lat
+    lon = float(match.group(5)) + float(match.group(6)) / 60
+    if match.group(4).upper() == "W":
+        lon = -lon
+    return Position(latitude=lat, longitude=lon)
+
+
+def _parse_decimal(text: str) -> Position | None:
+    regex = r"(-?\d+\.?\d*)[,\s]+(-?\d+\.?\d*)"
+    match = re.search(regex, text)
+    if not match:
+        return None
+    lat, lon = float(match.group(1)), float(match.group(2))
+    if not (-90 <= lat <= 90 and -180 <= lon <= 180):
+        return None
+    return Position(latitude=lat, longitude=lon)
+
+
+def parse_coordinates_from_text(text: str) -> Position | None:
+    """Extract the first valid lat/lon coordinates from a text string.
+
+    Supports DMS, DDM, and decimal formats. Returns None if no coordinates found.
+    """
+    return _parse_dms(text) or _parse_ddm(text) or _parse_decimal(text)
 
 
 def lua_to_dict(lua_table: Any) -> dict[Any, Any] | None:

--- a/src/foothold_sitac/foothold_api_router.py
+++ b/src/foothold_sitac/foothold_api_router.py
@@ -3,8 +3,17 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends
 from foothold_sitac.config import get_config
 from foothold_sitac.dependencies import get_active_sitac
-from foothold_sitac.foothold import Sitac, list_servers
-from foothold_sitac.schemas import MapConnection, MapData, MapEjectedPilot, MapPlayer, MapZone, Server, UnitGroup
+from foothold_sitac.foothold import Sitac, list_servers, parse_coordinates_from_text
+from foothold_sitac.schemas import (
+    MapConnection,
+    MapData,
+    MapEjectedPilot,
+    MapMission,
+    MapPlayer,
+    MapZone,
+    Server,
+    UnitGroup,
+)
 
 router = APIRouter()
 
@@ -100,6 +109,21 @@ async def foothold_get_map_data(
         # if pilot.player_name != "Unknown" # don't hide Unknown pilots, real pilots have this name
     ]
 
+    # Build missions with coordinates
+    missions_with_coords = []
+    for mission in sitac.missions:
+        pos = parse_coordinates_from_text(mission.description)
+        if pos:
+            missions_with_coords.append(
+                MapMission(
+                    title=mission.title,
+                    lat=pos.latitude,
+                    lon=pos.longitude,
+                    is_running=mission.is_running,
+                    is_escort_mission=mission.is_escort_mission,
+                )
+            )
+
     return MapData(
         updated_at=sitac.updated_at,
         age_seconds=age_seconds,
@@ -107,6 +131,7 @@ async def foothold_get_map_data(
         connections=connections,
         players=players,
         ejected_pilots=ejected_pilots,
+        missions=missions_with_coords,
         progress=sitac.campaign_progress,
         missions_count=len(sitac.missions),
         ejected_pilots_count=len(ejected_pilots),

--- a/src/foothold_sitac/schemas.py
+++ b/src/foothold_sitac/schemas.py
@@ -51,6 +51,14 @@ class MapEjectedPilot(BaseModel):
     lost_credits: float
 
 
+class MapMission(BaseModel):
+    title: str
+    lat: float
+    lon: float
+    is_running: bool
+    is_escort_mission: bool
+
+
 class MapData(BaseModel):
     updated_at: datetime
     age_seconds: float
@@ -58,6 +66,7 @@ class MapData(BaseModel):
     connections: list[MapConnection]
     players: list[MapPlayer] = Field(default_factory=list)
     ejected_pilots: list[MapEjectedPilot] = Field(default_factory=list)
+    missions: list[MapMission] = Field(default_factory=list)
     progress: float
     missions_count: int
     ejected_pilots_count: int = 0

--- a/src/foothold_sitac/static/css/map.css
+++ b/src/foothold_sitac/static/css/map.css
@@ -391,6 +391,24 @@
     font-size: 20px;
 }
 
+/* Mission markers */
+.mission-label {
+    background: transparent;
+    border: none;
+    white-space: nowrap;
+    font-weight: bold;
+    font-size: 16px;
+    color: #fbbf24;
+    text-shadow: 1px 1px 2px #000, -1px -1px 2px #000, 1px -1px 2px #000, -1px 1px 2px #000;
+    text-align: center;
+    pointer-events: auto;
+    cursor: pointer;
+}
+
+.mission-label .fa-crosshairs {
+    font-size: 20px;
+}
+
 /* Markpoint modal input */
 .markpoint-preview {
     margin-top: 8px;

--- a/src/foothold_sitac/static/js/map.js
+++ b/src/foothold_sitac/static/js/map.js
@@ -38,6 +38,7 @@ var playersLayer = null;
 var labelsLayer = null;
 var ejectionsLayer = null;
 var markpointsLayer = null;
+var missionsLayer = null;
 
 // Data arrays
 var zonesData = [];
@@ -45,6 +46,7 @@ var connectionsData = [];
 var playersData = [];
 var ejectionsData = [];
 var markpointsData = [];
+var missionsData = [];
 
 // Freshness widget state (REFRESH_INTERVAL is set by the page from config)
 var REFRESH_INTERVAL = 60;
@@ -95,6 +97,7 @@ function initMap() {
     labelsLayer = L.layerGroup().addTo(map);
     ejectionsLayer = L.layerGroup().addTo(map);
     markpointsLayer = L.layerGroup().addTo(map);
+    missionsLayer = L.layerGroup().addTo(map);
     rulerLayer = L.layerGroup().addTo(map);
 
     // Load markpoints from localStorage
@@ -106,6 +109,7 @@ function initMap() {
         updatePlayers();
         updateEjections();
         updateMarkpoints();
+        updateMissions();
     });
 
     // Cursor position display
@@ -366,6 +370,42 @@ function updateEjections() {
     });
 }
 
+// Mission markers
+function updateMissions() {
+    missionsLayer.clearLayers();
+    var zoom = map.getZoom();
+
+    missionsData.forEach(function(mission) {
+        var icon = '<i class="fa-solid fa-crosshairs"></i>';
+        var content = zoom >= 10
+            ? icon + '<br><span style="font-size: 9px;">' + mission.title + '</span>'
+            : icon;
+
+        var marker = L.marker([mission.lat, mission.lon], {
+            icon: L.divIcon({
+                className: 'mission-label',
+                html: content,
+                iconSize: [100, 40],
+                iconAnchor: [50, 20]
+            })
+        });
+
+        marker.bindTooltip(mission.title, {
+            direction: 'top',
+            offset: [0, -10]
+        });
+
+        marker.on('click', function(e) {
+            if (rulerMode) {
+                setRulerPoint(mission.lat, mission.lon, mission.title);
+                L.DomEvent.stopPropagation(e);
+            }
+        });
+
+        marker.addTo(missionsLayer);
+    });
+}
+
 function updateNavbar(progress, missionsCount, ejectedPilotsCount, blueCredits, redCredits) {
     // Update progress percentage
     var progressElement = document.getElementById('progress-value');
@@ -479,9 +519,11 @@ function loadData() {
             connectionsData = data.connections || [];
             playersData = data.players || [];
             ejectionsData = data.ejected_pilots || [];
+            missionsData = data.missions || [];
             updateConnections();
             updatePlayers();
             updateEjections();
+            updateMissions();
             updateLabels();
         })
         .catch(function(error) {

--- a/tests/fixtures/test_mission_coords/Missions/Saves/foothold.status
+++ b/tests/fixtures/test_mission_coords/Missions/Saves/foothold.status
@@ -1,0 +1,1 @@
+tests/fixtures/test_mission_coords/Missions/Saves/foothold_mission_coords.lua

--- a/tests/fixtures/test_mission_coords/Missions/Saves/foothold_mission_coords.lua
+++ b/tests/fixtures/test_mission_coords/Missions/Saves/foothold_mission_coords.lua
@@ -1,0 +1,5 @@
+zonePersistance = {}
+zonePersistance['zones'] = { ['TestZone1']={ ['upgradesUsed']=0,['side']=2,['active']=true,['destroyed']={ },['extraUpgrade']={ },['remainingUnits']={ },['wasBlue']=true,['lat_long']={ ['longitude']=39.0,['latitude']=44.0,['altitude']=0 },['firstCaptureByRed']=false,['level']=1,['triggers']={ ['missioncompleted']=0 } } }
+zonePersistance['missions'] = { [1]={ ['isEscortMission']=false,['description']='Strike a high-value building at these coordinates: Lat long: N 44°27\'14" E 39°44\'14" Elevation: 677 feet reward = 1000',['title']='Strike Building',['isRunning']=true },[2]={ ['isEscortMission']=true,['description']='Escort friendly convoy to base',['title']='Convoy Escort',['isRunning']=false } }
+zonePersistance['zonesDetails'] = { ['TestZone1']={ ['hidden']=false } }
+zonePersistance['playerStats'] = { }

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -247,3 +247,32 @@ def test_success_board_skips_zero_categories(client: TestClient) -> None:
     # All players have at least some stats, so most categories should appear
     # but Bomb runway: only Viper has 1, Falcon and Eagle have 0 → Viper wins
     assert "Runway Striker" in response.text
+
+
+# Mission markers tests
+
+
+def test_map_data_includes_mission_markers(client: TestClient) -> None:
+    """Test that missions with coordinates are included in map data"""
+    response = client.get("/api/foothold/test_mission_coords/map.json")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "missions" in data
+    assert len(data["missions"]) == 1
+    mission = data["missions"][0]
+    assert mission["title"] == "Strike Building"
+    assert mission["is_running"] is True
+    assert mission["is_escort_mission"] is False
+    assert abs(mission["lat"] - 44.4539) < 0.01
+    assert abs(mission["lon"] - 39.7372) < 0.01
+
+
+def test_map_data_excludes_missions_without_coords(client: TestClient) -> None:
+    """Test that missions without coordinates are not in map missions list"""
+    response = client.get("/api/foothold/test_missions/map.json")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["missions"] == []
+    assert data["missions_count"] == 2

--- a/tests/units/test_foothold.py
+++ b/tests/units/test_foothold.py
@@ -3,7 +3,16 @@ from typing import Any
 
 import pytest
 
-from foothold_sitac.foothold import Connection, EjectedPilot, Mission, Player, WeatherInfo, Zone, load_sitac
+from foothold_sitac.foothold import (
+    Connection,
+    EjectedPilot,
+    Mission,
+    Player,
+    WeatherInfo,
+    Zone,
+    load_sitac,
+    parse_coordinates_from_text,
+)
 
 
 @pytest.fixture
@@ -520,3 +529,53 @@ def test_load_sitac_without_weather_info() -> None:
     sitac = load_sitac(lua_path)
 
     assert sitac.weather_info is None
+
+
+# Coordinate parsing tests
+
+
+def test_parse_coordinates_dms() -> None:
+    """Test DMS coordinate parsing"""
+    text = "Strike at: N 44°27'14\" E 39°44'14\""
+    pos = parse_coordinates_from_text(text)
+    assert pos is not None
+    assert abs(pos.latitude - 44.4539) < 0.001
+    assert abs(pos.longitude - 39.7372) < 0.001
+
+
+def test_parse_coordinates_ddm() -> None:
+    """Test DDM coordinate parsing"""
+    text = "Target at: N 44°27.248' E 39°44.234'"
+    pos = parse_coordinates_from_text(text)
+    assert pos is not None
+    assert abs(pos.latitude - 44.4541) < 0.001
+    assert abs(pos.longitude - 39.7372) < 0.001
+
+
+def test_parse_coordinates_decimal() -> None:
+    """Test decimal coordinate parsing"""
+    text = "Target at coordinates: 44.4539, 39.7372"
+    pos = parse_coordinates_from_text(text)
+    assert pos is not None
+    assert abs(pos.latitude - 44.4539) < 0.001
+    assert abs(pos.longitude - 39.7372) < 0.001
+
+
+def test_parse_coordinates_none() -> None:
+    """Test text without coordinates returns None"""
+    pos = parse_coordinates_from_text("Destroy enemy forces at Hahn")
+    assert pos is None
+
+
+def test_parse_coordinates_full_example() -> None:
+    """Test the full example from issue #121 (MGRS + DMS + DDM)"""
+    text = (
+        "Strike a high-value building at these coordinates:  "
+        "MGRS: 37 T EK 58654 22580 Lat long: N 44°27'14\" E 39°44'14\" "
+        "Lat long Decimal Minutes: N 44°27.248' E 39°44.234'  "
+        "Elevation: 677 feet  reward = 1000"
+    )
+    pos = parse_coordinates_from_text(text)
+    assert pos is not None
+    assert abs(pos.latitude - 44.4539) < 0.001
+    assert abs(pos.longitude - 39.7372) < 0.001


### PR DESCRIPTION
## Summary by Sourcery

Display missions that contain parseable coordinates as target markers on the map and expose them via the map API.

New Features:
- Parse latitude/longitude coordinates from mission description text in multiple formats (DMS, DDM, decimal) for use in map features.
- Expose missions with valid coordinates through the map.json API response and render them as mission markers on the map UI.

Documentation:
- Document the new mission marker behavior in the changelog.

Tests:
- Add unit tests for coordinate parsing across supported formats and for handling texts without coordinates.
- Add integration tests and fixtures to verify that missions with coordinates are included in map data and missions without coordinates are excluded.