### PR TITLE
add cache mechanism, add force refresh button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Add server-side cache based on `foothold.status` file mtime to avoid re-parsing Lua files on every request ([#130](https://github.com/VEAF/foothold-sitac/issues/130))
+- Click on the freshness widget to force an immediate data refresh ([#130](https://github.com/VEAF/foothold-sitac/issues/130))
 - Add `WeatherInfo` model to parse weather data from Lua persistence files with float support for `wind_direction` ([#122](https://github.com/VEAF/foothold-sitac/issues/122))
 - Display missions with coordinates as target markers on the map ([#121](https://github.com/VEAF/foothold-sitac/issues/121))
 - Display CTLD FARPs on the map with coordinate modal on click ([#125](https://github.com/VEAF/foothold-sitac/issues/125))

--- a/src/foothold_sitac/cache.py
+++ b/src/foothold_sitac/cache.py
@@ -1,0 +1,78 @@
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from foothold_sitac.foothold import (
+    Sitac,
+    detect_foothold_mission_path,
+    get_foothold_server_status_path,
+    load_sitac,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheEntry:
+    status_mtime: float
+    mission_path: Path
+    sitac: Sitac
+    checked_at: datetime = field(default_factory=datetime.now)
+
+
+_cache: dict[str, CacheEntry] = {}
+
+
+def get_cached_sitac(server_name: str) -> Sitac | None:
+    """Return a cached Sitac if the status file hasn't changed, or reload it.
+
+    Returns None if the server has no valid foothold data.
+    """
+    status_path = get_foothold_server_status_path(server_name)
+
+    if not status_path.is_file():
+        _cache.pop(server_name, None)
+        return None
+
+    current_mtime = status_path.stat().st_mtime
+    cached = _cache.get(server_name)
+
+    if cached is not None and cached.status_mtime == current_mtime:
+        logger.debug("Cache hit for server '%s'", server_name)
+        cached.checked_at = datetime.now()
+        return cached.sitac
+
+    logger.info("Cache miss for server '%s', reloading sitac", server_name)
+    mission_path = detect_foothold_mission_path(server_name)
+    if mission_path is None:
+        _cache.pop(server_name, None)
+        return None
+
+    sitac = load_sitac(mission_path)
+    _cache[server_name] = CacheEntry(
+        status_mtime=current_mtime,
+        mission_path=mission_path,
+        sitac=sitac,
+        checked_at=datetime.now(),
+    )
+    return sitac
+
+
+def get_checked_at(server_name: str) -> datetime | None:
+    """Return when the cache was last checked for this server."""
+    cached = _cache.get(server_name)
+    return cached.checked_at if cached else None
+
+
+def get_status_mtime(server_name: str) -> datetime | None:
+    """Return the status file mtime for this server's cached entry."""
+    cached = _cache.get(server_name)
+    if cached is None:
+        return None
+    return datetime.fromtimestamp(cached.status_mtime)
+
+
+def clear_cache() -> None:
+    """Clear all cached entries."""
+    _cache.clear()

--- a/src/foothold_sitac/dependencies.py
+++ b/src/foothold_sitac/dependencies.py
@@ -1,38 +1,30 @@
 from fastapi import HTTPException, status
-from foothold_sitac.foothold import (
-    Sitac,
-    detect_foothold_mission_path,
-    get_server_path_by_name,
-    load_sitac,
-)
+
+from foothold_sitac.cache import get_cached_sitac
+from foothold_sitac.foothold import Sitac, get_server_path_by_name
 
 
 def get_sitac_or_none(server: str) -> Sitac | None:
-    """Load sitac for a server, return None if not available"""
+    """Load sitac for a server, return None if not available (uses cache)."""
     server_path = get_server_path_by_name(server)
 
     if not server_path.is_dir():
         return None
 
-    mission_path = detect_foothold_mission_path(server)
-
-    if not mission_path:
-        return None
-
-    return load_sitac(mission_path)
+    return get_cached_sitac(server)
 
 
 def get_active_sitac(server: str) -> Sitac:
-    """Dependency injection of sitac by server name"""
+    """Dependency injection of sitac by server name (uses cache)."""
 
     server_path = get_server_path_by_name(server)
 
     if not server_path.is_dir():
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"server {server} not found")
 
-    mission_path = detect_foothold_mission_path(server)
+    sitac = get_cached_sitac(server)
 
-    if not mission_path:
+    if sitac is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"mission not found for server {server}")
 
-    return load_sitac(mission_path)
+    return sitac

--- a/src/foothold_sitac/foothold_api_router.py
+++ b/src/foothold_sitac/foothold_api_router.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Annotated, Any
 from fastapi import APIRouter, Depends
+from foothold_sitac.cache import get_checked_at, get_status_mtime
 from foothold_sitac.config import get_config
 from foothold_sitac.dependencies import get_active_sitac
 from foothold_sitac.foothold import Sitac, list_servers, parse_coordinates_from_text
@@ -31,6 +32,7 @@ async def foothold_get_sitac(sitac: Annotated[Sitac, Depends(get_active_sitac)])
 
 @router.get("/{server}/map.json", response_model=MapData)
 async def foothold_get_map_data(
+    server: str,
     sitac: Annotated[Sitac, Depends(get_active_sitac)],
 ) -> Any:
     show_forces = get_config().features.show_zone_forces
@@ -82,7 +84,10 @@ async def foothold_get_map_data(
                 )
             )
 
-    age_seconds = (datetime.now() - sitac.updated_at).total_seconds()
+    status_mtime = get_status_mtime(server)
+    reference_time = status_mtime if status_mtime else sitac.updated_at
+    age_seconds = (datetime.now() - reference_time).total_seconds()
+    is_fresh = get_checked_at(server) is not None and age_seconds < 130
 
     # Build players list
     players = [
@@ -131,6 +136,7 @@ async def foothold_get_map_data(
     return MapData(
         updated_at=sitac.updated_at,
         age_seconds=age_seconds,
+        is_fresh=is_fresh,
         zones=zones,
         connections=connections,
         players=players,

--- a/src/foothold_sitac/schemas.py
+++ b/src/foothold_sitac/schemas.py
@@ -68,6 +68,7 @@ class MapFarp(BaseModel):
 class MapData(BaseModel):
     updated_at: datetime
     age_seconds: float
+    is_fresh: bool = True
     zones: list[MapZone]
     connections: list[MapConnection]
     players: list[MapPlayer] = Field(default_factory=list)

--- a/src/foothold_sitac/static/css/map.css
+++ b/src/foothold_sitac/static/css/map.css
@@ -23,6 +23,7 @@
     align-items: center;
     gap: 6px;
     box-shadow: var(--shadow-sm);
+    cursor: pointer;
 }
 
 #freshness-widget.fresh {

--- a/src/foothold_sitac/static/js/map.js
+++ b/src/foothold_sitac/static/js/map.js
@@ -55,6 +55,7 @@ var REFRESH_INTERVAL = 60;
 var nextRefresh = REFRESH_INTERVAL;
 var dataAgeSeconds = 0;
 var isConnected = true;
+var isDataFresh = true;
 
 // Ruler state
 var rulerMode = false;
@@ -540,7 +541,7 @@ function updateFreshnessWidget() {
         widget.classList.add('disconnected');
         countdown.textContent = 'Offline';
         tooltip.textContent = 'Connection to server lost';
-    } else if (dataAgeSeconds < 90) {
+    } else if (isDataFresh) {
         widget.classList.add('fresh');
         countdown.textContent = nextRefresh + 's';
         tooltip.textContent = 'Data up to date (' + Math.round(dataAgeSeconds) + 's) • Refresh in ' + nextRefresh + 's';
@@ -561,6 +562,7 @@ function loadData() {
         .then(function(data) {
             isConnected = true;
             dataAgeSeconds = data.age_seconds;
+            isDataFresh = data.is_fresh;
             nextRefresh = REFRESH_INTERVAL;
             updateFreshnessWidget();
             updateNavbar(data.progress, data.missions_count, data.ejected_pilots_count, data.blue_credits, data.red_credits);
@@ -602,6 +604,11 @@ function loadData() {
             isConnected = false;
             updateFreshnessWidget();
         });
+}
+
+// Force immediate data refresh (called on freshness widget click)
+function forceRefresh() {
+    loadData();
 }
 
 // Start countdown timer and data refresh

--- a/src/foothold_sitac/templates/foothold/map.html
+++ b/src/foothold_sitac/templates/foothold/map.html
@@ -53,7 +53,7 @@
 <div id="map"></div>
 
 <!-- Freshness widget -->
-<div id="freshness-widget" class="fresh">
+<div id="freshness-widget" class="fresh" onclick="forceRefresh()">
     <div class="progress-ring-container">
         <svg class="progress-ring" width="24" height="24">
             <circle class="progress-ring-bg" cx="12" cy="12" r="10" />

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 import pytest
 from fastapi.testclient import TestClient
 
+from foothold_sitac.cache import clear_cache
 from foothold_sitac.config import get_config
 from foothold_sitac.main import app
 
@@ -10,7 +11,9 @@ from foothold_sitac.main import app
 @pytest.fixture
 def client() -> Generator[TestClient, None, None]:
     get_config.cache_clear()
+    clear_cache()
     yield TestClient(app)
+    clear_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/units/test_cache.py
+++ b/tests/units/test_cache.py
@@ -1,0 +1,147 @@
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from foothold_sitac.cache import _cache, clear_cache, get_cached_sitac, get_checked_at
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    clear_cache()
+
+
+@pytest.fixture
+def status_file(tmp_path: Path) -> Path:
+    """Create a minimal foothold.status file pointing to a Lua fixture."""
+    lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+    server_dir = tmp_path / "test_server" / "Missions" / "Saves"
+    server_dir.mkdir(parents=True)
+    status_file = server_dir / "foothold.status"
+    status_file.write_text(str(lua_path.absolute()))
+    return status_file
+
+
+def test_cache_miss_calls_load_sitac(tmp_path: Path, status_file: Path) -> None:
+    """First call should parse the Lua file."""
+    with patch("foothold_sitac.cache.get_foothold_server_status_path", return_value=status_file):
+        with patch("foothold_sitac.cache.detect_foothold_mission_path") as mock_detect:
+            lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+            mock_detect.return_value = lua_path
+            with patch("foothold_sitac.cache.load_sitac") as mock_load:
+                from foothold_sitac.foothold import load_sitac as real_load
+
+                mock_load.side_effect = real_load
+                result = get_cached_sitac("test_server")
+                assert result is not None
+                mock_load.assert_called_once()
+
+
+def test_cache_hit_returns_same_object(tmp_path: Path, status_file: Path) -> None:
+    """Second call with unchanged mtime should return the cached Sitac (same instance)."""
+    with patch("foothold_sitac.cache.get_foothold_server_status_path", return_value=status_file):
+        with patch("foothold_sitac.cache.detect_foothold_mission_path") as mock_detect:
+            lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+            mock_detect.return_value = lua_path
+            with patch("foothold_sitac.cache.load_sitac") as mock_load:
+                from foothold_sitac.foothold import load_sitac as real_load
+
+                mock_load.side_effect = real_load
+                first = get_cached_sitac("test_server")
+                second = get_cached_sitac("test_server")
+                assert first is second
+                mock_load.assert_called_once()
+
+
+def test_cache_invalidation_on_mtime_change(tmp_path: Path, status_file: Path) -> None:
+    """Touching the status file should trigger a reload."""
+    with patch("foothold_sitac.cache.get_foothold_server_status_path", return_value=status_file):
+        with patch("foothold_sitac.cache.detect_foothold_mission_path") as mock_detect:
+            lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+            mock_detect.return_value = lua_path
+            with patch("foothold_sitac.cache.load_sitac") as mock_load:
+                from foothold_sitac.foothold import load_sitac as real_load
+
+                mock_load.side_effect = real_load
+                first = get_cached_sitac("test_server")
+
+                # Touch the status file to change mtime
+                time.sleep(0.05)
+                os.utime(status_file, None)
+
+                second = get_cached_sitac("test_server")
+                assert first is not second
+                assert mock_load.call_count == 2
+
+
+def test_returns_none_when_status_file_missing() -> None:
+    """Should return None if the status file doesn't exist."""
+    missing_path = Path("/nonexistent/foothold.status")
+    with patch("foothold_sitac.cache.get_foothold_server_status_path", return_value=missing_path):
+        result = get_cached_sitac("no_server")
+        assert result is None
+
+
+def test_clears_stale_cache_when_status_file_disappears(tmp_path: Path, status_file: Path) -> None:
+    """Removing the status file should clear the cache entry."""
+    with patch("foothold_sitac.cache.get_foothold_server_status_path", return_value=status_file):
+        with patch("foothold_sitac.cache.detect_foothold_mission_path") as mock_detect:
+            lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+            mock_detect.return_value = lua_path
+            with patch("foothold_sitac.cache.load_sitac") as mock_load:
+                from foothold_sitac.foothold import load_sitac as real_load
+
+                mock_load.side_effect = real_load
+                get_cached_sitac("test_server")
+                assert "test_server" in _cache
+
+                # Remove status file
+                status_file.unlink()
+                result = get_cached_sitac("test_server")
+                assert result is None
+                assert "test_server" not in _cache
+
+
+def test_clear_cache_empties_all_entries(tmp_path: Path, status_file: Path) -> None:
+    """clear_cache() should remove all entries."""
+    with patch("foothold_sitac.cache.get_foothold_server_status_path", return_value=status_file):
+        with patch("foothold_sitac.cache.detect_foothold_mission_path") as mock_detect:
+            lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+            mock_detect.return_value = lua_path
+            with patch("foothold_sitac.cache.load_sitac") as mock_load:
+                from foothold_sitac.foothold import load_sitac as real_load
+
+                mock_load.side_effect = real_load
+                get_cached_sitac("test_server")
+                assert len(_cache) == 1
+
+                clear_cache()
+                assert len(_cache) == 0
+
+
+def test_checked_at_updated_on_cache_hit(tmp_path: Path, status_file: Path) -> None:
+    """checked_at should be updated on cache hit."""
+    with patch("foothold_sitac.cache.get_foothold_server_status_path", return_value=status_file):
+        with patch("foothold_sitac.cache.detect_foothold_mission_path") as mock_detect:
+            lua_path = Path("tests/fixtures/test_hidden/Missions/Saves/foothold_hidden_test.lua")
+            mock_detect.return_value = lua_path
+            with patch("foothold_sitac.cache.load_sitac") as mock_load:
+                from foothold_sitac.foothold import load_sitac as real_load
+
+                mock_load.side_effect = real_load
+                get_cached_sitac("test_server")
+                first_checked = get_checked_at("test_server")
+                assert first_checked is not None
+
+                time.sleep(0.05)
+                get_cached_sitac("test_server")
+                second_checked = get_checked_at("test_server")
+                assert second_checked is not None
+                assert second_checked > first_checked
+
+
+def test_get_checked_at_returns_none_for_unknown_server() -> None:
+    """get_checked_at should return None for uncached servers."""
+    assert get_checked_at("nonexistent") is None


### PR DESCRIPTION
## Summary by Sourcery

Introduce a server-side Sitac caching layer and expose freshness information to support on-demand map data refreshes.

New Features:
- Add a server-side Sitac cache keyed by foothold status file mtime to avoid re-parsing Lua files on every request.
- Allow users to click the freshness widget to force an immediate map data refresh.
- Expose an is_fresh flag in the map data API and use it in the frontend to reflect data freshness more accurately.

Enhancements:
- Update Sitac dependency resolution to load missions via the shared cache instead of re-detecting and re-loading each time.
- Base map data age calculations on the status file mtime when available for more accurate freshness reporting.

Documentation:
- Document the new caching mechanism and clickable freshness widget in the changelog.

Tests:
- Add unit tests covering cache hits, invalidation, disappearance of the status file, and cache timestamp tracking.
- Update integration tests to clear the cache between runs to ensure isolation.